### PR TITLE
chore: Bump the time crate requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 serde_with = "1.13.0"
 thiserror = "1.0.31"
-time = { version = "0.3.9", features = ["serde", "serde-well-known"] }
+time = { version = "0.3.11", features = ["serde", "serde-well-known"] }
 
 [dev-dependencies]
 time = { version = "0.3.9", features = ["macros"] }


### PR DESCRIPTION
time-0.3.10 introduced a bug.

See: https://github.com/time-rs/time/issues/479