### PR TITLE
Extend via trait associated types

### DIFF
--- a/src/buildable.rs
+++ b/src/buildable.rs
@@ -95,10 +95,12 @@ mod test {
 
         dbg!(&t);
 
-        let t = Thing::<TestExtension>::builder()
-            .other(|o| o.test("Success"))
-            .build();
+        let mut tb = Thing::<TestExtension>::builder();
+
+        let t = tb.other(|o| o.test("Success")).build();
+        let t2 = tb.other(|o| o.test("Second")).build();
 
         dbg!(&t);
+        dbg!(&t2);
     }
 }

--- a/src/buildable.rs
+++ b/src/buildable.rs
@@ -1,7 +1,7 @@
 use crate::thing::Thing;
 use crate::traits::*;
 
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Default, Debug)]
 pub struct ThingBuilder<E: Extension> {
     other: <E::Thing as Buildable>::B,
 }
@@ -36,6 +36,8 @@ impl<E: Extension> ThingBuilder<E> {
 
 #[cfg(test)]
 mod test {
+    use std::sync::{Arc, Mutex};
+
     use super::*;
     use crate::hlist::Nil;
     use crate::thing::Thing;
@@ -46,9 +48,10 @@ mod test {
         test: String,
     }
 
-    #[derive(Default, Clone, Debug, PartialEq)]
+    #[derive(Default, Debug)]
     struct TestThingBuilder {
         test: String,
+        something: Option<Arc<Mutex<usize>>>,
     }
 
     impl TestThingBuilder {

--- a/src/buildable.rs
+++ b/src/buildable.rs
@@ -1,0 +1,101 @@
+use crate::thing::Thing;
+use crate::traits::*;
+
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct ThingBuilder<E: Extension> {
+    other: <E::Thing as Buildable>::B,
+}
+
+impl<E: Extension> Buildable for Thing<E> {
+    type B = ThingBuilder<E>;
+}
+
+impl<E: Extension> Builder for ThingBuilder<E> {
+    type B = Thing<E>;
+
+    fn build(&self) -> Self::B {
+        let other = self.other.build();
+
+        Self::B {
+            other,
+            ..Default::default()
+        }
+    }
+}
+
+impl<E: Extension> ThingBuilder<E> {
+    fn other<Fun>(&mut self, mut f: Fun) -> &mut Self
+    where
+        Fun: FnMut(&mut <E::Thing as Buildable>::B) -> &mut <E::Thing as Buildable>::B,
+    {
+        f(&mut self.other);
+
+        self
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::hlist::Nil;
+    use crate::thing::Thing;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
+    struct TestThingExtension {
+        test: String,
+    }
+
+    #[derive(Default, Clone, Debug, PartialEq)]
+    struct TestThingBuilder {
+        test: String,
+    }
+
+    impl TestThingBuilder {
+        fn test(&mut self, test: impl Into<String>) -> &mut Self {
+            self.test = test.into();
+            self
+        }
+    }
+
+    impl Buildable for TestThingExtension {
+        type B = TestThingBuilder;
+
+        fn builder() -> Self::B {
+            TestThingBuilder::default()
+        }
+    }
+
+    impl Builder for TestThingBuilder {
+        type B = TestThingExtension;
+
+        fn build(&self) -> Self::B {
+            TestThingExtension {
+                test: self.test.clone(),
+            }
+        }
+    }
+
+    #[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
+    struct TestExtension;
+
+    impl Extension for TestExtension {
+        type Thing = TestThingExtension;
+        type InteractionAffordance = Nil;
+        type Form = Nil;
+        type DataSchema = Nil;
+    }
+
+    #[test]
+    fn build_thing() {
+        let t = Thing::<Nil>::builder().build();
+
+        dbg!(&t);
+
+        let t = Thing::<TestExtension>::builder()
+            .other(|o| o.test("Success"))
+            .build();
+
+        dbg!(&t);
+    }
+}

--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -1,0 +1,156 @@
+use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Nil;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Cons<T, U = Nil> {
+    #[serde(flatten)]
+    pub(crate) head: T,
+    #[serde(flatten)]
+    pub(crate) tail: U,
+}
+
+pub(crate) trait HList: Sized {
+    const SIZE: usize;
+}
+
+impl HList for Nil {
+    const SIZE: usize = 0;
+}
+
+impl<T, U> HList for Cons<T, U>
+where
+    U: HList,
+{
+    const SIZE: usize = U::SIZE + 1;
+}
+
+impl<T> Cons<T, Nil> {
+    #[inline]
+    pub(crate) fn new_head(head: T) -> Self {
+        Cons { head, tail: Nil {} }
+    }
+}
+
+impl<T, U> Cons<T, U> {
+    #[inline]
+    pub(crate) fn add<V>(self, value: V) -> Cons<V, Self> {
+        Cons {
+            head: value,
+            tail: self,
+        }
+    }
+}
+
+impl Serialize for Nil {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_struct("Nil", 0)?.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Nil {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct NilStruct {}
+
+        NilStruct::deserialize(deserializer)?;
+        Ok(Nil)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Value};
+
+    use super::*;
+
+    #[test]
+    fn chain() {
+        let v = Cons::new_head("A".to_string())
+            .add("B".to_string())
+            .add("C".to_string());
+
+        dbg!(&v);
+    }
+
+    #[test]
+    fn serialize_flatten_nil() {
+        #[derive(Debug, Serialize)]
+        struct A {
+            a: i32,
+            #[serde(flatten)]
+            b: Nil,
+        }
+
+        let value = serde_json::to_value(A { a: 42, b: Nil {} }).unwrap();
+        dbg!(&value);
+        assert_eq!(value.get("a").unwrap(), &Value::Number(42.into()));
+        assert!(value.get("b").is_none());
+    }
+
+    #[test]
+    fn serialize_cons() {
+        #[derive(Debug, Serialize)]
+        struct C {
+            bar: &'static str,
+        }
+        #[derive(Debug, Serialize)]
+        struct B {
+            foo: usize,
+        }
+        #[derive(Debug, Serialize)]
+        struct A {
+            a: i32,
+            #[serde(flatten)]
+            b: Cons<C, Cons<B, Nil>>,
+        }
+
+        let value = serde_json::to_value(A {
+            a: 42,
+            b: Cons::new_head(B { foo: 42 }).add(C { bar: "42" }),
+        })
+        .unwrap();
+        dbg!(&value);
+        assert_eq!(value.get("a").unwrap(), &Value::Number(42.into()));
+        assert_eq!(value.get("foo").unwrap(), &Value::Number(42.into()));
+    }
+
+    #[test]
+    fn deserialize_cons() {
+        #[derive(Debug, Deserialize)]
+        struct C {
+            bar: String,
+        }
+        #[derive(Debug, Deserialize)]
+        struct B {
+            foo: usize,
+        }
+        #[derive(Debug, Deserialize)]
+        struct A {
+            a: i32,
+            #[serde(flatten)]
+            b: Cons<Cons<B, C>, Nil>,
+        }
+
+        let v = json!({
+            "a": 42,
+            "foo": 42,
+            "bar": "42",
+        });
+
+        let a: A = serde_json::from_value(v).unwrap();
+
+        dbg!(&a);
+
+        assert_eq!(a.a, 42);
+        assert_eq!(a.b.head.head.foo, 42);
+        assert_eq!(a.b.head.tail.bar, String::from("42"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,5 @@
 //! operate with complex descriptions.
 
 pub mod builder;
+mod hlist;
 pub mod thing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,7 @@
 //! operate with complex descriptions.
 
 // pub mod builder;
+pub mod buildable;
 mod hlist;
 pub mod thing;
+pub mod traits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,6 @@
 //! an high level builder to ensure a valid TD is built and a set of accessors to make easier to
 //! operate with complex descriptions.
 
-pub mod builder;
+// pub mod builder;
 mod hlist;
 pub mod thing;

--- a/src/thing.rs
+++ b/src/thing.rs
@@ -22,6 +22,10 @@ pub(crate) type DataSchemaMap = HashMap<String, DataSchema>;
 pub const TD_CONTEXT_10: &str = "https://www.w3.org/2019/wot/td/v1";
 pub const TD_CONTEXT_11: &str = "https://www.w3.org/2019/wot/td/v1.1";
 
+fn default_context() -> Value {
+    TD_CONTEXT_11.into()
+}
+
 /// An abstraction of a physical or a virtual entity
 ///
 /// It contains metadata and a description of its interfaces.
@@ -34,7 +38,7 @@ pub struct Thing {
     // https://www.w3.org/TR/json-ld11/#the-context
     // Let's take a value for now and assume we'll use the json-ld crate later
     /// A [JSON-LD @context](https://www.w3.org/TR/json-ld11/#the-context)
-    #[serde(rename = "@context", default = "Thing::default_context")]
+    #[serde(rename = "@context", default = "default_context")]
     pub context: Value,
 
     /// A unique identifier
@@ -127,10 +131,6 @@ impl Thing {
     #[inline]
     pub fn build(title: impl Into<String>) -> ThingBuilder {
         ThingBuilder::new(title)
-    }
-
-    fn default_context() -> Value {
-        TD_CONTEXT_11.into()
     }
 }
 

--- a/src/thing.rs
+++ b/src/thing.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 use serde_with::{serde_as, skip_serializing_none, DeserializeAs, OneOrMany, Same};
 use time::OffsetDateTime;
 
-use crate::builder::ThingBuilder;
+// use crate::builder::ThingBuilder;
 
 pub(crate) type MultiLanguage = HashMap<String, String>;
 pub(crate) type DataSchemaMap = HashMap<String, DataSchema>;
@@ -126,6 +126,7 @@ pub struct Thing {
     pub profile: Option<Vec<String>>,
 }
 
+/*
 impl Thing {
     /// Shorthand for [ThingBuilder::new].
     #[inline]
@@ -133,6 +134,7 @@ impl Thing {
         ThingBuilder::new(title)
     }
 }
+*/
 
 #[serde_as]
 #[skip_serializing_none]

--- a/src/thing.rs
+++ b/src/thing.rs
@@ -26,6 +26,16 @@ fn default_context() -> Value {
     TD_CONTEXT_11.into()
 }
 
+pub trait Extension {
+    type Thing: Clone + std::fmt::Debug + Default + PartialEq;
+}
+
+use crate::hlist::Nil;
+
+impl Extension for Nil {
+    type Thing = Nil;
+}
+
 /// An abstraction of a physical or a virtual entity
 ///
 /// It contains metadata and a description of its interfaces.
@@ -33,7 +43,7 @@ fn default_context() -> Value {
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Thing {
+pub struct Thing<E: Extension = Nil> {
     // The context can be arbitrarily complex
     // https://www.w3.org/TR/json-ld11/#the-context
     // Let's take a value for now and assume we'll use the json-ld crate later
@@ -124,6 +134,9 @@ pub struct Thing {
     #[serde(default)]
     #[serde_as(as = "Option<OneOrMany<_>>")]
     pub profile: Option<Vec<String>>,
+
+    #[serde(flatten)]
+    pub other: E::Thing,
 }
 
 /*

--- a/src/thing.rs
+++ b/src/thing.rs
@@ -16,6 +16,8 @@ use time::OffsetDateTime;
 
 // use crate::builder::ThingBuilder;
 
+use crate::traits::*;
+
 pub(crate) type MultiLanguage = HashMap<String, String>;
 pub(crate) type DataSchemaMap<E> = HashMap<String, DataSchema<E>>;
 
@@ -26,13 +28,6 @@ fn default_context() -> Value {
     TD_CONTEXT_11.into()
 }
 
-pub trait Extension {
-    type Thing: Clone + std::fmt::Debug + Default + PartialEq;
-    type InteractionAffordance: Clone + std::fmt::Debug + Default + PartialEq;
-    type Form: Clone + std::fmt::Debug + Default + PartialEq;
-    type DataSchema: Clone + std::fmt::Debug + Default + PartialEq;
-}
-
 use crate::hlist::Nil;
 
 impl Extension for Nil {
@@ -40,6 +35,22 @@ impl Extension for Nil {
     type InteractionAffordance = Nil;
     type Form = Nil;
     type DataSchema = Nil;
+}
+
+impl Builder for Nil {
+    type B = Nil;
+
+    fn build(&self) -> Nil {
+        Nil
+    }
+}
+
+impl Buildable for Nil {
+    type B = Nil;
+
+    fn builder() -> Nil {
+        Nil
+    }
 }
 
 /// An abstraction of a physical or a virtual entity

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,21 @@
+// TODO: use better trait bounds
+pub trait Extension: Default + Clone + std::fmt::Debug + PartialEq {
+    type Thing: Buildable;
+    type InteractionAffordance: Buildable;
+    type Form: Buildable;
+    type DataSchema: Buildable;
+}
+
+pub trait Builder: Default + Clone + std::fmt::Debug + PartialEq {
+    type B: Buildable<B = Self>;
+
+    fn build(&self) -> Self::B;
+}
+
+pub trait Buildable: Default + Clone + std::fmt::Debug + PartialEq {
+    type B: Builder<B = Self>;
+
+    fn builder() -> Self::B {
+        Self::B::default()
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,7 +6,7 @@ pub trait Extension: Default + Clone + std::fmt::Debug + PartialEq {
     type DataSchema: Buildable;
 }
 
-pub trait Builder: Default + Clone + std::fmt::Debug + PartialEq {
+pub trait Builder: Default + std::fmt::Debug {
     type B: Buildable<B = Self>;
 
     fn build(&self) -> Self::B;


### PR DESCRIPTION
- Add `other` to all the elements that need it
   - [x] Thing
   - [x] InteractionAffordance
   - [x] Form
   - [x] DataSchema
   - [ ] SecurityScheme
- [x] Implement builder-buildable for the extension trait
- [ ] Test the builder can store anything and get away with it
- [ ] Figure out a simpler way to express the bounds for `Buildable`
- [ ] Refactor the builders to use builder-buildable
- [ ] Write more tests