### PR TITLE
Make Thing and ThingBuilder extendable

### DIFF
--- a/src/builder/affordance.rs
+++ b/src/builder/affordance.rs
@@ -1828,11 +1828,13 @@ pub(super) fn check_form_builders<Other: ExtendableThing>(
 
 #[cfg(test)]
 mod test {
+    use serde::{Deserialize, Serialize};
+
     use crate::{
         builder::data_schema::{
             BuildableDataSchema, NumberDataSchemaBuilderLike, PartialDataSchemaBuilder,
         },
-        hlist::Nil,
+        hlist::{Cons, Nil},
         thing::{DataSchemaSubtype, DefaultedFormOperations, FormOperation, NumberSchema},
     };
 
@@ -2277,6 +2279,498 @@ mod test {
                     ..Default::default()
                 }),
                 other: Nil,
+            },
+        );
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct A(i32);
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct B(String);
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct ThingExtA {}
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct InteractionAffordanceExtA {
+        a: A,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct PropertyAffordanceExtA {
+        b: A,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct ActionAffordanceExtA {
+        b: A,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct EventAffordanceExtA {
+        c: A,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct FormExtA {
+        d: A,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct ExpectedResponseExtA {
+        e: A,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct DataSchemaExtA {
+        f: A,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct ThingExtB {}
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct InteractionAffordanceExtB {
+        g: B,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct PropertyAffordanceExtB {
+        h: B,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct ActionAffordanceExtB {
+        i: B,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct EventAffordanceExtB {
+        j: B,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct FormExtB {
+        k: B,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct ExpectedResponseExtB {
+        l: B,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct DataSchemaExtB {
+        m: B,
+    }
+
+    impl ExtendableThing for ThingExtA {
+        type InteractionAffordance = InteractionAffordanceExtA;
+        type PropertyAffordance = PropertyAffordanceExtA;
+        type ActionAffordance = ActionAffordanceExtA;
+        type EventAffordance = EventAffordanceExtA;
+        type Form = FormExtA;
+        type ExpectedResponse = ExpectedResponseExtA;
+        type DataSchema = DataSchemaExtA;
+        type ObjectSchema = ();
+        type ArraySchema = ();
+    }
+
+    impl ExtendableThing for ThingExtB {
+        type InteractionAffordance = InteractionAffordanceExtB;
+        type PropertyAffordance = PropertyAffordanceExtB;
+        type ActionAffordance = ActionAffordanceExtB;
+        type EventAffordance = EventAffordanceExtB;
+        type Form = FormExtB;
+        type ExpectedResponse = ExpectedResponseExtB;
+        type DataSchema = DataSchemaExtB;
+        type ObjectSchema = ();
+        type ArraySchema = ();
+    }
+
+    #[test]
+    fn extend_interaction() {
+        let affordance: InteractionAffordance<Cons<ThingExtB, Cons<ThingExtA, Nil>>> =
+            InteractionAffordanceBuilder::<Cons<ThingExtB, Cons<ThingExtA, Nil>>, _>::empty()
+                .title("title")
+                .ext(InteractionAffordanceExtA { a: A(1) })
+                .uri_variable("x", |b| {
+                    b.ext(DataSchemaExtA { f: A(2) })
+                        .ext_with(|| DataSchemaExtB {
+                            m: B("a".to_string()),
+                        })
+                        .finish_extend()
+                        .null()
+                })
+                .ext_with(|| InteractionAffordanceExtB {
+                    g: B("b".to_string()),
+                })
+                .form(|b| {
+                    b.ext(FormExtA { d: A(3) })
+                        .ext(FormExtB {
+                            k: B("c".to_string()),
+                        })
+                        .href("href")
+                })
+                .into();
+
+        assert_eq!(
+            affordance,
+            InteractionAffordance {
+                title: Some("title".to_string()),
+                uri_variables: Some(
+                    [(
+                        "x".to_string(),
+                        DataSchema {
+                            subtype: Some(DataSchemaSubtype::Null),
+                            other: Cons::new_head(DataSchemaExtA { f: A(2) }).add(DataSchemaExtB {
+                                m: B("a".to_string())
+                            }),
+                            attype: Default::default(),
+                            title: Default::default(),
+                            titles: Default::default(),
+                            description: Default::default(),
+                            descriptions: Default::default(),
+                            constant: Default::default(),
+                            unit: Default::default(),
+                            one_of: Default::default(),
+                            enumeration: Default::default(),
+                            read_only: Default::default(),
+                            write_only: Default::default(),
+                            format: Default::default(),
+                        }
+                    )]
+                    .into_iter()
+                    .collect()
+                ),
+                forms: vec![Form {
+                    href: "href".to_string(),
+                    other: Cons::new_head(FormExtA { d: A(3) }).add(FormExtB {
+                        k: B("c".to_string())
+                    }),
+                    op: Default::default(),
+                    content_type: Default::default(),
+                    content_coding: Default::default(),
+                    subprotocol: Default::default(),
+                    security: Default::default(),
+                    scopes: Default::default(),
+                    response: Default::default(),
+                }],
+                other: Cons::new_head(InteractionAffordanceExtA { a: A(1) }).add(
+                    InteractionAffordanceExtB {
+                        g: B("b".to_string())
+                    }
+                ),
+                attype: Default::default(),
+                titles: Default::default(),
+                description: Default::default(),
+                descriptions: Default::default(),
+            },
+        );
+    }
+
+    #[test]
+    fn extend_property() {
+        let builder: UsablePropertyAffordanceBuilder<Cons<ThingExtB, Cons<ThingExtA, Nil>>> =
+            PropertyAffordanceBuilder::<Cons<ThingExtB, Cons<ThingExtA, Nil>>, _, _, _>::empty()
+                .ext(PropertyAffordanceExtA { b: A(1) })
+                .title("title")
+                .ext_interaction(InteractionAffordanceExtA { a: A(2) })
+                .ext_data_schema(DataSchemaExtA { f: A(4) })
+                .uri_variable("x", |b| {
+                    b.ext(DataSchemaExtA { f: A(3) })
+                        .ext_with(|| DataSchemaExtB {
+                            m: B("a".to_string()),
+                        })
+                        .finish_extend()
+                        .null()
+                })
+                .ext_data_schema_with(|| DataSchemaExtB {
+                    m: B("d".to_string()),
+                })
+                .ext_interaction_with(|| InteractionAffordanceExtB {
+                    g: B("b".to_string()),
+                })
+                .finish_extend_data_schema()
+                .ext_with(|| PropertyAffordanceExtB {
+                    h: B("c".to_string()),
+                })
+                .null()
+                .into();
+        let affordance: PropertyAffordance<Cons<ThingExtB, Cons<ThingExtA, Nil>>> = builder.into();
+
+        assert_eq!(
+            affordance,
+            PropertyAffordance {
+                interaction: InteractionAffordance {
+                    other: Cons::new_head(InteractionAffordanceExtA { a: A(2) }).add(
+                        InteractionAffordanceExtB {
+                            g: B("b".to_string())
+                        }
+                    ),
+                    uri_variables: Some(
+                        [(
+                            "x".to_string(),
+                            DataSchema {
+                                subtype: Some(DataSchemaSubtype::Null),
+                                other: Cons::new_head(DataSchemaExtA { f: A(3) }).add(
+                                    DataSchemaExtB {
+                                        m: B("a".to_string())
+                                    }
+                                ),
+                                attype: Default::default(),
+                                title: Default::default(),
+                                titles: Default::default(),
+                                description: Default::default(),
+                                descriptions: Default::default(),
+                                constant: Default::default(),
+                                unit: Default::default(),
+                                one_of: Default::default(),
+                                enumeration: Default::default(),
+                                read_only: Default::default(),
+                                write_only: Default::default(),
+                                format: Default::default(),
+                            }
+                        )]
+                        .into_iter()
+                        .collect()
+                    ),
+                    attype: Default::default(),
+                    title: Some("title".to_string()),
+                    titles: Default::default(),
+                    description: Default::default(),
+                    descriptions: Default::default(),
+                    forms: Default::default(),
+                },
+                data_schema: DataSchema {
+                    title: Some("title".to_string()),
+                    subtype: Some(DataSchemaSubtype::Null),
+                    other: Cons::new_head(DataSchemaExtA { f: A(4) }).add(DataSchemaExtB {
+                        m: B("d".to_string())
+                    }),
+                    attype: Default::default(),
+                    titles: Default::default(),
+                    description: Default::default(),
+                    descriptions: Default::default(),
+                    constant: Default::default(),
+                    unit: Default::default(),
+                    one_of: Default::default(),
+                    enumeration: Default::default(),
+                    read_only: Default::default(),
+                    write_only: Default::default(),
+                    format: Default::default(),
+                },
+                other: Cons::new_head(PropertyAffordanceExtA { b: A(1) }).add(
+                    PropertyAffordanceExtB {
+                        h: B("c".to_string())
+                    }
+                ),
+                observable: Default::default(),
+            }
+        );
+    }
+
+    #[test]
+    fn extend_event() {
+        let builder: UsableEventAffordanceBuilder<Cons<ThingExtB, Cons<ThingExtA, Nil>>> =
+            EventAffordanceBuilder::<Cons<ThingExtB, Cons<ThingExtA, Nil>>, _, _>::empty()
+                .title("title")
+                .ext_interaction(InteractionAffordanceExtA { a: A(1) })
+                .uri_variable("x", |b| {
+                    b.ext(DataSchemaExtA { f: A(2) })
+                        .ext_with(|| DataSchemaExtB {
+                            m: B("a".to_string()),
+                        })
+                        .finish_extend()
+                        .null()
+                })
+                .ext_interaction_with(|| InteractionAffordanceExtB {
+                    g: B("b".to_string()),
+                })
+                .ext(EventAffordanceExtA { c: A(3) })
+                .ext_with(|| EventAffordanceExtB {
+                    j: B("c".to_string()),
+                })
+                .subscription(|b| {
+                    b.ext(DataSchemaExtA { f: A(4) })
+                        .ext_with(|| DataSchemaExtB {
+                            m: B("d".to_string()),
+                        })
+                        .finish_extend()
+                        .null()
+                });
+        let affordance: EventAffordance<Cons<ThingExtB, Cons<ThingExtA, Nil>>> = builder.into();
+
+        assert_eq!(
+            affordance,
+            EventAffordance {
+                interaction: InteractionAffordance {
+                    title: Some("title".to_string()),
+                    uri_variables: Some(
+                        [(
+                            "x".to_string(),
+                            DataSchema {
+                                subtype: Some(DataSchemaSubtype::Null),
+                                other: Cons::new_head(DataSchemaExtA { f: A(2) }).add(
+                                    DataSchemaExtB {
+                                        m: B("a".to_string())
+                                    }
+                                ),
+                                attype: Default::default(),
+                                title: Default::default(),
+                                titles: Default::default(),
+                                description: Default::default(),
+                                descriptions: Default::default(),
+                                constant: Default::default(),
+                                unit: Default::default(),
+                                one_of: Default::default(),
+                                enumeration: Default::default(),
+                                read_only: Default::default(),
+                                write_only: Default::default(),
+                                format: Default::default(),
+                            }
+                        )]
+                        .into_iter()
+                        .collect()
+                    ),
+                    other: Cons::new_head(InteractionAffordanceExtA { a: A(1) }).add(
+                        InteractionAffordanceExtB {
+                            g: B("b".to_string())
+                        }
+                    ),
+                    attype: Default::default(),
+                    titles: Default::default(),
+                    description: Default::default(),
+                    descriptions: Default::default(),
+                    forms: Default::default(),
+                },
+                subscription: Some(DataSchema {
+                    subtype: Some(DataSchemaSubtype::Null),
+                    other: Cons::new_head(DataSchemaExtA { f: A(4) }).add(DataSchemaExtB {
+                        m: B("d".to_string())
+                    }),
+                    attype: Default::default(),
+                    title: Default::default(),
+                    titles: Default::default(),
+                    description: Default::default(),
+                    descriptions: Default::default(),
+                    constant: Default::default(),
+                    unit: Default::default(),
+                    one_of: Default::default(),
+                    enumeration: Default::default(),
+                    read_only: Default::default(),
+                    write_only: Default::default(),
+                    format: Default::default(),
+                }),
+                other: Cons::new_head(EventAffordanceExtA { c: A(3) }).add(EventAffordanceExtB {
+                    j: B("c".to_string())
+                }),
+                data: Default::default(),
+                data_response: Default::default(),
+                cancellation: Default::default(),
+            },
+        );
+    }
+
+    #[test]
+    fn extend_action() {
+        let builder: UsableActionAffordanceBuilder<Cons<ThingExtB, Cons<ThingExtA, Nil>>> =
+            ActionAffordanceBuilder::<Cons<ThingExtB, Cons<ThingExtA, Nil>>, _, _>::empty()
+                .title("title")
+                .ext_interaction(InteractionAffordanceExtA { a: A(1) })
+                .uri_variable("x", |b| {
+                    b.ext(DataSchemaExtA { f: A(2) })
+                        .ext_with(|| DataSchemaExtB {
+                            m: B("a".to_string()),
+                        })
+                        .finish_extend()
+                        .null()
+                })
+                .ext_interaction_with(|| InteractionAffordanceExtB {
+                    g: B("b".to_string()),
+                })
+                .ext(ActionAffordanceExtA { b: A(3) })
+                .ext_with(|| ActionAffordanceExtB {
+                    i: B("c".to_string()),
+                })
+                .input(|b| {
+                    b.ext(DataSchemaExtA { f: A(4) })
+                        .ext_with(|| DataSchemaExtB {
+                            m: B("d".to_string()),
+                        })
+                        .finish_extend()
+                        .null()
+                });
+        let affordance: ActionAffordance<Cons<ThingExtB, Cons<ThingExtA, Nil>>> = builder.into();
+
+        assert_eq!(
+            affordance,
+            ActionAffordance {
+                interaction: InteractionAffordance {
+                    title: Some("title".to_string()),
+                    uri_variables: Some(
+                        [(
+                            "x".to_string(),
+                            DataSchema {
+                                subtype: Some(DataSchemaSubtype::Null),
+                                other: Cons::new_head(DataSchemaExtA { f: A(2) }).add(
+                                    DataSchemaExtB {
+                                        m: B("a".to_string())
+                                    }
+                                ),
+                                attype: Default::default(),
+                                title: Default::default(),
+                                titles: Default::default(),
+                                description: Default::default(),
+                                descriptions: Default::default(),
+                                constant: Default::default(),
+                                unit: Default::default(),
+                                one_of: Default::default(),
+                                enumeration: Default::default(),
+                                read_only: Default::default(),
+                                write_only: Default::default(),
+                                format: Default::default(),
+                            }
+                        )]
+                        .into_iter()
+                        .collect()
+                    ),
+                    other: Cons::new_head(InteractionAffordanceExtA { a: A(1) }).add(
+                        InteractionAffordanceExtB {
+                            g: B("b".to_string())
+                        }
+                    ),
+                    attype: Default::default(),
+                    titles: Default::default(),
+                    description: Default::default(),
+                    descriptions: Default::default(),
+                    forms: Default::default(),
+                },
+                input: Some(DataSchema {
+                    subtype: Some(DataSchemaSubtype::Null),
+                    other: Cons::new_head(DataSchemaExtA { f: A(4) }).add(DataSchemaExtB {
+                        m: B("d".to_string())
+                    }),
+                    attype: Default::default(),
+                    title: Default::default(),
+                    titles: Default::default(),
+                    description: Default::default(),
+                    descriptions: Default::default(),
+                    constant: Default::default(),
+                    unit: Default::default(),
+                    one_of: Default::default(),
+                    enumeration: Default::default(),
+                    read_only: Default::default(),
+                    write_only: Default::default(),
+                    format: Default::default(),
+                }),
+                other: Cons::new_head(ActionAffordanceExtA { b: A(3) }).add(ActionAffordanceExtB {
+                    i: B("c".to_string())
+                }),
+                output: Default::default(),
+                safe: Default::default(),
+                idempotent: Default::default(),
+                synchronous: Default::default(),
             },
         );
     }

--- a/src/builder/affordance.rs
+++ b/src/builder/affordance.rs
@@ -575,6 +575,12 @@ where
         OtherInteractionAffordance,
         OtherPropertyAffordance,
     >;
+    type ExtendableArray = PropertyAffordanceBuilder<
+        Other,
+        DataSchema::ExtendableArray,
+        OtherInteractionAffordance,
+        OtherPropertyAffordance,
+    >;
     type ExtendedArray = PropertyAffordanceBuilder<
         Other,
         DataSchema::ExtendedArray,
@@ -590,6 +596,12 @@ where
     type Integer = PropertyAffordanceBuilder<
         Other,
         DataSchema::Integer,
+        OtherInteractionAffordance,
+        OtherPropertyAffordance,
+    >;
+    type ExtendableObject = PropertyAffordanceBuilder<
+        Other,
+        DataSchema::ExtendableObject,
         OtherInteractionAffordance,
         OtherPropertyAffordance,
     >;
@@ -614,10 +626,12 @@ where
 
     impl_property_affordance_builder_delegator!(
         array where AS: Default => Self::ExtendedArray,
+        array_ext<F>(f: F) where F: FnOnce(AS::Empty) -> AS, AS: Extendable => Self::ExtendableArray,
         bool => Self::Stateless,
         number => Self::Number,
         integer => Self::Integer,
         object where OS: Default => Self::ExtendedObject,
+        object_ext<F>(f: F) where F: FnOnce(OS::Empty) -> OS, OS: Extendable => Self::ExtendableObject,
         string => Self::String,
         null => Self::Stateless,
         constant(value: impl Into<Value>) => Self::Constant,

--- a/src/extend.rs
+++ b/src/extend.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Serialize};
+
+use crate::hlist::{Cons, HList, Nil};
+
+pub trait ExtendablePiece: Serialize + for<'a> Deserialize<'a> {}
+
+impl<T> ExtendablePiece for T where T: Serialize + for<'a> Deserialize<'a> {}
+
+pub trait ExtendableThing {
+    type InteractionAffordance: ExtendablePiece;
+    type PropertyAffordance: ExtendablePiece;
+    type ActionAffordance: ExtendablePiece;
+    type EventAffordance: ExtendablePiece;
+    type Form: ExtendablePiece;
+    type ExpectedResponse: ExtendablePiece;
+    type DataSchema: ExtendablePiece;
+    type ObjectSchema: ExtendablePiece;
+    type ArraySchema: ExtendablePiece;
+}
+
+impl ExtendableThing for Nil {
+    type InteractionAffordance = Nil;
+    type PropertyAffordance = Nil;
+    type ActionAffordance = Nil;
+    type EventAffordance = Nil;
+    type Form = Nil;
+    type ExpectedResponse = Nil;
+    type DataSchema = Nil;
+    type ObjectSchema = Nil;
+    type ArraySchema = Nil;
+}
+
+impl<T, U> ExtendableThing for Cons<T, U>
+where
+    T: ExtendableThing,
+    U: ExtendableThing,
+{
+    type InteractionAffordance = Cons<T::InteractionAffordance, U::InteractionAffordance>;
+    type PropertyAffordance = Cons<T::PropertyAffordance, U::PropertyAffordance>;
+    type ActionAffordance = Cons<T::ActionAffordance, U::ActionAffordance>;
+    type EventAffordance = Cons<T::EventAffordance, U::EventAffordance>;
+    type Form = Cons<T::Form, U::Form>;
+    type ExpectedResponse = Cons<T::ExpectedResponse, U::ExpectedResponse>;
+    type DataSchema = Cons<T::DataSchema, U::DataSchema>;
+    type ObjectSchema = Cons<T::ObjectSchema, U::ObjectSchema>;
+    type ArraySchema = Cons<T::ArraySchema, U::ArraySchema>;
+}
+
+pub trait Extendable {
+    type Empty;
+
+    fn empty() -> Self::Empty;
+}
+
+pub trait Extend<T>: Sized {
+    type Target;
+
+    fn ext(self, t: T) -> Self::Target;
+
+    fn ext_with<F>(self, f: F) -> Self::Target
+    where
+        F: FnOnce() -> T,
+    {
+        self.ext(f())
+    }
+}
+
+impl Extendable for Nil {
+    type Empty = Nil;
+
+    fn empty() -> Self {
+        Nil
+    }
+}
+
+impl<T> Extend<T> for Nil {
+    type Target = Cons<T, Nil>;
+
+    fn ext(self, t: T) -> Self::Target {
+        Cons::new_head(t)
+    }
+}
+
+impl<T, U> Extendable for Cons<T, U>
+where
+    Cons<T, U>: HList,
+{
+    type Empty = Nil;
+
+    fn empty() -> Self::Empty {
+        Nil
+    }
+}
+
+impl<T, U, V> Extend<T> for Cons<U, V> {
+    type Target = Cons<T, Cons<U, V>>;
+
+    fn ext(self, t: T) -> Self::Target {
+        self.add(t)
+    }
+}

--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -1,0 +1,172 @@
+use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Nil;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Cons<T, U = Nil> {
+    #[serde(flatten)]
+    pub(crate) head: T,
+    #[serde(flatten)]
+    pub(crate) tail: U,
+}
+
+pub(crate) trait HList: Sized {
+    const SIZE: usize;
+}
+
+impl HList for Nil {
+    const SIZE: usize = 0;
+}
+
+impl<T, U> HList for Cons<T, U>
+where
+    U: HList,
+{
+    const SIZE: usize = U::SIZE + 1;
+}
+
+impl<T> Cons<T, Nil> {
+    #[inline]
+    pub(crate) fn new_head(head: T) -> Self {
+        Cons { head, tail: Nil {} }
+    }
+}
+
+impl<T, U> Cons<T, U> {
+    #[inline]
+    pub(crate) fn add<V>(self, value: V) -> Cons<V, Self> {
+        Cons {
+            head: value,
+            tail: self,
+        }
+    }
+}
+
+impl Serialize for Nil {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_struct("Nil", 0)?.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Nil {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct NilStruct {}
+
+        NilStruct::deserialize(deserializer)?;
+        Ok(Nil)
+    }
+}
+
+impl From<()> for Nil {
+    fn from(_: ()) -> Self {
+        Nil
+    }
+}
+
+impl From<Nil> for () {
+    fn from(_: Nil) -> Self {}
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Value};
+
+    use super::*;
+
+    #[test]
+    fn chain() {
+        let list = Cons::new_head("A").add(2).add("C".to_string());
+
+        assert_eq!(
+            list,
+            Cons {
+                head: "C".to_string(),
+                tail: Cons {
+                    head: 2,
+                    tail: Cons {
+                        head: "A",
+                        tail: Nil,
+                    },
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn serialize_flatten_nil() {
+        #[derive(Debug, Serialize)]
+        struct A {
+            a: i32,
+            #[serde(flatten)]
+            b: Nil,
+        }
+
+        let value = serde_json::to_value(A { a: 42, b: Nil {} }).unwrap();
+        assert_eq!(value.get("a").unwrap(), &Value::Number(42.into()));
+        assert!(value.get("b").is_none());
+    }
+
+    #[test]
+    fn serialize_cons() {
+        #[derive(Debug, Serialize)]
+        struct C {
+            bar: &'static str,
+        }
+        #[derive(Debug, Serialize)]
+        struct B {
+            foo: usize,
+        }
+        #[derive(Debug, Serialize)]
+        struct A {
+            a: i32,
+            #[serde(flatten)]
+            b: Cons<C, Cons<B, Nil>>,
+        }
+
+        let value = serde_json::to_value(A {
+            a: 42,
+            b: Cons::new_head(B { foo: 42 }).add(C { bar: "42" }),
+        })
+        .unwrap();
+        assert_eq!(value.get("a").unwrap(), &Value::Number(42.into()));
+        assert_eq!(value.get("foo").unwrap(), &Value::Number(42.into()));
+    }
+
+    #[test]
+    fn deserialize_cons() {
+        #[derive(Debug, Deserialize)]
+        struct C {
+            bar: String,
+        }
+        #[derive(Debug, Deserialize)]
+        struct B {
+            foo: usize,
+        }
+        #[derive(Debug, Deserialize)]
+        struct A {
+            a: i32,
+            #[serde(flatten)]
+            b: Cons<Cons<B, C>, Nil>,
+        }
+
+        let v = json!({
+            "a": 42,
+            "foo": 42,
+            "bar": "42",
+        });
+
+        let a: A = serde_json::from_value(v).unwrap();
+
+        assert_eq!(a.a, 42);
+        assert_eq!(a.b.head.head.foo, 42);
+        assert_eq!(a.b.head.tail.bar, String::from("42"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,6 @@
 //! operate with complex descriptions.
 
 pub mod builder;
+pub mod extend;
 mod hlist;
 pub mod thing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,5 @@
 //! operate with complex descriptions.
 
 pub mod builder;
+mod hlist;
 pub mod thing;


### PR DESCRIPTION
Allow _basic_ extension of `Thing` and its members. This is the very first working POW for this approach, we are still missing full extendability and the relative API is not set in stone.

Closes #37 