### PR TITLE
Expose Heterogeneous Lists (HList)

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3296,7 +3296,7 @@ mod tests {
                 forms: Some(vec![Form {
                     op: DefaultedFormOperations::Custom(vec![FormOperation::ReadAllProperties]),
                     href: "href".to_string(),
-                    other: Cons::new_head(FormExtA {
+                    other: Nil::cons(FormExtA {
                         a: "test".to_string()
                     })
                     .cons(FormExtB { b: B(42) }),
@@ -3391,13 +3391,13 @@ mod tests {
             Form {
                 op: DefaultedFormOperations::Custom(vec![FormOperation::ReadProperty]),
                 href: "href".to_string(),
-                other: Cons::new_head(FormExtA {
+                other: Nil::cons(FormExtA {
                     a: A("a".to_string())
                 })
                 .cons(FormExtB { c: B(1) }),
                 response: Some(ExpectedResponse {
                     content_type: "application/json".to_string(),
-                    other: Cons::new_head(ExpectedResponseExtA {
+                    other: Nil::cons(ExpectedResponseExtA {
                         b: A("b".to_string())
                     })
                     .cons(ExpectedResponseExtB { d: B(2) })
@@ -3667,7 +3667,7 @@ mod tests {
             Thing {
                 context: TD_CONTEXT_11.into(),
                 title: "thing title".to_string(),
-                other: Cons::new_head(ThingA { a: 1, b: 2 })
+                other: Nil::cons(ThingA { a: 1, b: 2 })
                     .cons(ThingB {})
                     .cons(ThingC { c: 3 }),
                 id: Some("id".to_string()),
@@ -3677,7 +3677,7 @@ mod tests {
                         "uri_variable".to_string(),
                         DataSchema {
                             subtype: Some(DataSchemaSubtype::Array(ArraySchema::default())),
-                            other: Cons::new_head(DataSchemaExtA { h: 4 })
+                            other: Nil::cons(DataSchemaExtA { h: 4 })
                                 .cons(())
                                 .cons(DataSchemaExtC { t: 5 }),
                             attype: Default::default(),
@@ -3702,7 +3702,7 @@ mod tests {
                         "property".to_string(),
                         PropertyAffordance {
                             interaction: InteractionAffordance {
-                                other: Cons::new_head(InteractionAffordanceExtA { d: 6 })
+                                other: Nil::cons(InteractionAffordanceExtA { d: 6 })
                                     .cons(InteractionAffordanceExtB { j: 9. })
                                     .cons(InteractionAffordanceExtC { p: 10 }),
                                 attype: Default::default(),
@@ -3714,7 +3714,7 @@ mod tests {
                                     href: "href1".to_string(),
                                     response: Some(ExpectedResponse {
                                         content_type: "application/json".to_string(),
-                                        other: Cons::new_head(ExpectedResponseExtA { g: 16 })
+                                        other: Nil::cons(ExpectedResponseExtA { g: 16 })
                                             .cons(ExpectedResponseExtB { n: 17 })
                                             .cons(ExpectedResponseExtC { s: 18 })
                                     }),
@@ -3723,7 +3723,7 @@ mod tests {
                                         content_type: Some("application/xml".to_string()),
                                         schema: Some("schema".to_string()),
                                     }]),
-                                    other: Cons::new_head(()).cons(FormExtB { m: 19 }).cons(()),
+                                    other: Nil::cons(()).cons(FormExtB { m: 19 }).cons(()),
                                     op: Default::default(),
                                     content_type: Default::default(),
                                     content_coding: Default::default(),
@@ -3735,13 +3735,13 @@ mod tests {
                             },
                             data_schema: DataSchema {
                                 subtype: Some(DataSchemaSubtype::Object(ObjectSchema {
-                                    other: Cons::new_head(ObjectSchemaExtA { i: 11 })
+                                    other: Nil::cons(ObjectSchemaExtA { i: 11 })
                                         .cons(ObjectSchemaExtB { o: 12 })
                                         .cons(ObjectSchemaExtC { u: 13 }),
                                     properties: Default::default(),
                                     required: Default::default(),
                                 })),
-                                other: Cons::new_head(DataSchemaExtA { h: 7 })
+                                other: Nil::cons(DataSchemaExtA { h: 7 })
                                     .cons(())
                                     .cons(DataSchemaExtC { t: 8 }),
                                 attype: Default::default(),
@@ -3757,7 +3757,7 @@ mod tests {
                                 write_only: Default::default(),
                                 format: Default::default(),
                             },
-                            other: Cons::new_head(())
+                            other: Nil::cons(())
                                 .cons(PropertyAffordanceExtB { k: 14. })
                                 .cons(PropertyAffordanceExtC { q: 15 }),
                             observable: Default::default(),
@@ -3779,7 +3779,7 @@ mod tests {
                                             subtype: Some(DataSchemaSubtype::Array(
                                                 ArraySchema::default()
                                             )),
-                                            other: Cons::new_head(DataSchemaExtA { h: 27 })
+                                            other: Nil::cons(DataSchemaExtA { h: 27 })
                                                 .cons(())
                                                 .cons(DataSchemaExtC { t: 28 }),
                                             attype: Default::default(),
@@ -3799,7 +3799,7 @@ mod tests {
                                     .into_iter()
                                     .collect()
                                 ),
-                                other: Cons::new_head(InteractionAffordanceExtA { d: 22 })
+                                other: Nil::cons(InteractionAffordanceExtA { d: 22 })
                                     .cons(InteractionAffordanceExtB { j: 23. })
                                     .cons(InteractionAffordanceExtC { p: 24 }),
                                 attype: Default::default(),
@@ -3815,7 +3815,7 @@ mod tests {
                                     maximum: Some(5.),
                                     ..Default::default()
                                 })),
-                                other: Cons::new_head(DataSchemaExtA { h: 25 })
+                                other: Nil::cons(DataSchemaExtA { h: 25 })
                                     .cons(())
                                     .cons(DataSchemaExtC { t: 26 }),
                                 attype: Default::default(),
@@ -3830,7 +3830,7 @@ mod tests {
                                 write_only: Default::default(),
                                 format: Default::default(),
                             }),
-                            other: Cons::new_head(ActionAffordanceExtA { e: 20 })
+                            other: Nil::cons(ActionAffordanceExtA { e: 20 })
                                 .cons(())
                                 .cons(ActionAffordanceExtC { r: 21 }),
                             output: Default::default(),
@@ -3847,7 +3847,7 @@ mod tests {
                         "event".to_string(),
                         EventAffordance {
                             interaction: InteractionAffordance {
-                                other: Cons::new_head(InteractionAffordanceExtA { d: 31 })
+                                other: Nil::cons(InteractionAffordanceExtA { d: 31 })
                                     .cons(InteractionAffordanceExtB { j: 32. })
                                     .cons(InteractionAffordanceExtC { p: 33 }),
                                 attype: Default::default(),
@@ -3860,7 +3860,7 @@ mod tests {
                             },
                             data: Some(DataSchema {
                                 subtype: Some(DataSchemaSubtype::Boolean),
-                                other: Cons::new_head(DataSchemaExtA { h: 34 })
+                                other: Nil::cons(DataSchemaExtA { h: 34 })
                                     .cons(())
                                     .cons(DataSchemaExtC { t: 35 }),
                                 attype: Default::default(),
@@ -3876,7 +3876,7 @@ mod tests {
                                 write_only: Default::default(),
                                 format: Default::default(),
                             }),
-                            other: Cons::new_head(EventAffordanceExtA { f: 29 })
+                            other: Nil::cons(EventAffordanceExtA { f: 29 })
                                 .cons(EventAffordanceExtB { l: 30 })
                                 .cons(()),
                             subscription: Default::default(),
@@ -3891,11 +3891,11 @@ mod tests {
                     href: "href2".to_string(),
                     response: Some(ExpectedResponse {
                         content_type: "test".to_string(),
-                        other: Cons::new_head(ExpectedResponseExtA { g: 37 })
+                        other: Nil::cons(ExpectedResponseExtA { g: 37 })
                             .cons(ExpectedResponseExtB { n: 38 })
                             .cons(ExpectedResponseExtC { s: 39 })
                     }),
-                    other: Cons::new_head(()).cons(FormExtB { m: 36 }).cons(()),
+                    other: Nil::cons(()).cons(FormExtB { m: 36 }).cons(()),
                     op: DefaultedFormOperations::Custom(vec![FormOperation::ReadAllProperties]),
                     content_type: Default::default(),
                     content_coding: Default::default(),
@@ -3909,7 +3909,7 @@ mod tests {
                         "schema".to_string(),
                         DataSchema {
                             subtype: Some(DataSchemaSubtype::Null),
-                            other: Cons::new_head(DataSchemaExtA { h: 40 })
+                            other: Nil::cons(DataSchemaExtA { h: 40 })
                                 .cons(())
                                 .cons(DataSchemaExtC { t: 41 }),
                             attype: Default::default(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -987,7 +987,7 @@ impl<T> MultiLanguageBuilder<T> {
     /// Add the language-specific variant
     ///
     /// NOTE: The language key is currently free-form
-    pub fn add(&mut self, language: impl Into<String>, value: impl Into<T>) -> &mut Self {
+    pub fn cons(&mut self, language: impl Into<String>, value: impl Into<T>) -> &mut Self {
         self.values.insert(language.into(), value.into());
         self
     }
@@ -1905,7 +1905,7 @@ mod tests {
     #[test]
     fn titles() {
         let thing = ThingBuilder::<Nil, _>::new("MyLampThing")
-            .titles(|ml| ml.add("en", "My lamp").add("it", "La mia lampada"))
+            .titles(|ml| ml.cons("en", "My lamp").cons("it", "La mia lampada"))
             .build()
             .unwrap();
 
@@ -1929,7 +1929,7 @@ mod tests {
     fn descriptions() {
         let thing = ThingBuilder::<Nil, _>::new("MyLampThing")
             .description("My Lamp")
-            .descriptions(|ml| ml.add("en", "My lamp").add("it", "La mia lampada"))
+            .descriptions(|ml| ml.cons("en", "My lamp").cons("it", "La mia lampada"))
             .build()
             .unwrap();
 
@@ -2060,7 +2060,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
+                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2107,7 +2107,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
+                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2160,7 +2160,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
+                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2213,7 +2213,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
+                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2268,7 +2268,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
+                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2326,7 +2326,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
+                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2383,7 +2383,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
+                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -3299,7 +3299,7 @@ mod tests {
                     other: Cons::new_head(FormExtA {
                         a: "test".to_string()
                     })
-                    .add(FormExtB { b: B(42) }),
+                    .cons(FormExtB { b: B(42) }),
                     content_type: Default::default(),
                     content_coding: Default::default(),
                     subprotocol: Default::default(),
@@ -3394,13 +3394,13 @@ mod tests {
                 other: Cons::new_head(FormExtA {
                     a: A("a".to_string())
                 })
-                .add(FormExtB { c: B(1) }),
+                .cons(FormExtB { c: B(1) }),
                 response: Some(ExpectedResponse {
                     content_type: "application/json".to_string(),
                     other: Cons::new_head(ExpectedResponseExtA {
                         b: A("b".to_string())
                     })
-                    .add(ExpectedResponseExtB { d: B(2) })
+                    .cons(ExpectedResponseExtB { d: B(2) })
                 }),
                 content_type: Default::default(),
                 content_coding: Default::default(),
@@ -3668,8 +3668,8 @@ mod tests {
                 context: TD_CONTEXT_11.into(),
                 title: "thing title".to_string(),
                 other: Cons::new_head(ThingA { a: 1, b: 2 })
-                    .add(ThingB {})
-                    .add(ThingC { c: 3 }),
+                    .cons(ThingB {})
+                    .cons(ThingC { c: 3 }),
                 id: Some("id".to_string()),
                 description: Some("description".to_string()),
                 uri_variables: Some(
@@ -3678,8 +3678,8 @@ mod tests {
                         DataSchema {
                             subtype: Some(DataSchemaSubtype::Array(ArraySchema::default())),
                             other: Cons::new_head(DataSchemaExtA { h: 4 })
-                                .add(())
-                                .add(DataSchemaExtC { t: 5 }),
+                                .cons(())
+                                .cons(DataSchemaExtC { t: 5 }),
                             attype: Default::default(),
                             title: Default::default(),
                             titles: Default::default(),
@@ -3703,8 +3703,8 @@ mod tests {
                         PropertyAffordance {
                             interaction: InteractionAffordance {
                                 other: Cons::new_head(InteractionAffordanceExtA { d: 6 })
-                                    .add(InteractionAffordanceExtB { j: 9. })
-                                    .add(InteractionAffordanceExtC { p: 10 }),
+                                    .cons(InteractionAffordanceExtB { j: 9. })
+                                    .cons(InteractionAffordanceExtC { p: 10 }),
                                 attype: Default::default(),
                                 title: Default::default(),
                                 titles: Default::default(),
@@ -3715,15 +3715,15 @@ mod tests {
                                     response: Some(ExpectedResponse {
                                         content_type: "application/json".to_string(),
                                         other: Cons::new_head(ExpectedResponseExtA { g: 16 })
-                                            .add(ExpectedResponseExtB { n: 17 })
-                                            .add(ExpectedResponseExtC { s: 18 })
+                                            .cons(ExpectedResponseExtB { n: 17 })
+                                            .cons(ExpectedResponseExtC { s: 18 })
                                     }),
                                     additional_responses: Some(vec![AdditionalExpectedResponse {
                                         success: true,
                                         content_type: Some("application/xml".to_string()),
                                         schema: Some("schema".to_string()),
                                     }]),
-                                    other: Cons::new_head(()).add(FormExtB { m: 19 }).add(()),
+                                    other: Cons::new_head(()).cons(FormExtB { m: 19 }).cons(()),
                                     op: Default::default(),
                                     content_type: Default::default(),
                                     content_coding: Default::default(),
@@ -3736,14 +3736,14 @@ mod tests {
                             data_schema: DataSchema {
                                 subtype: Some(DataSchemaSubtype::Object(ObjectSchema {
                                     other: Cons::new_head(ObjectSchemaExtA { i: 11 })
-                                        .add(ObjectSchemaExtB { o: 12 })
-                                        .add(ObjectSchemaExtC { u: 13 }),
+                                        .cons(ObjectSchemaExtB { o: 12 })
+                                        .cons(ObjectSchemaExtC { u: 13 }),
                                     properties: Default::default(),
                                     required: Default::default(),
                                 })),
                                 other: Cons::new_head(DataSchemaExtA { h: 7 })
-                                    .add(())
-                                    .add(DataSchemaExtC { t: 8 }),
+                                    .cons(())
+                                    .cons(DataSchemaExtC { t: 8 }),
                                 attype: Default::default(),
                                 title: Default::default(),
                                 titles: Default::default(),
@@ -3758,8 +3758,8 @@ mod tests {
                                 format: Default::default(),
                             },
                             other: Cons::new_head(())
-                                .add(PropertyAffordanceExtB { k: 14. })
-                                .add(PropertyAffordanceExtC { q: 15 }),
+                                .cons(PropertyAffordanceExtB { k: 14. })
+                                .cons(PropertyAffordanceExtC { q: 15 }),
                             observable: Default::default(),
                         }
                     )]
@@ -3780,8 +3780,8 @@ mod tests {
                                                 ArraySchema::default()
                                             )),
                                             other: Cons::new_head(DataSchemaExtA { h: 27 })
-                                                .add(())
-                                                .add(DataSchemaExtC { t: 28 }),
+                                                .cons(())
+                                                .cons(DataSchemaExtC { t: 28 }),
                                             attype: Default::default(),
                                             title: Default::default(),
                                             titles: Default::default(),
@@ -3800,8 +3800,8 @@ mod tests {
                                     .collect()
                                 ),
                                 other: Cons::new_head(InteractionAffordanceExtA { d: 22 })
-                                    .add(InteractionAffordanceExtB { j: 23. })
-                                    .add(InteractionAffordanceExtC { p: 24 }),
+                                    .cons(InteractionAffordanceExtB { j: 23. })
+                                    .cons(InteractionAffordanceExtC { p: 24 }),
                                 attype: Default::default(),
                                 titles: Default::default(),
                                 description: Default::default(),
@@ -3816,8 +3816,8 @@ mod tests {
                                     ..Default::default()
                                 })),
                                 other: Cons::new_head(DataSchemaExtA { h: 25 })
-                                    .add(())
-                                    .add(DataSchemaExtC { t: 26 }),
+                                    .cons(())
+                                    .cons(DataSchemaExtC { t: 26 }),
                                 attype: Default::default(),
                                 titles: Default::default(),
                                 description: Default::default(),
@@ -3831,8 +3831,8 @@ mod tests {
                                 format: Default::default(),
                             }),
                             other: Cons::new_head(ActionAffordanceExtA { e: 20 })
-                                .add(())
-                                .add(ActionAffordanceExtC { r: 21 }),
+                                .cons(())
+                                .cons(ActionAffordanceExtC { r: 21 }),
                             output: Default::default(),
                             safe: Default::default(),
                             idempotent: Default::default(),
@@ -3848,8 +3848,8 @@ mod tests {
                         EventAffordance {
                             interaction: InteractionAffordance {
                                 other: Cons::new_head(InteractionAffordanceExtA { d: 31 })
-                                    .add(InteractionAffordanceExtB { j: 32. })
-                                    .add(InteractionAffordanceExtC { p: 33 }),
+                                    .cons(InteractionAffordanceExtB { j: 32. })
+                                    .cons(InteractionAffordanceExtC { p: 33 }),
                                 attype: Default::default(),
                                 title: Default::default(),
                                 titles: Default::default(),
@@ -3861,8 +3861,8 @@ mod tests {
                             data: Some(DataSchema {
                                 subtype: Some(DataSchemaSubtype::Boolean),
                                 other: Cons::new_head(DataSchemaExtA { h: 34 })
-                                    .add(())
-                                    .add(DataSchemaExtC { t: 35 }),
+                                    .cons(())
+                                    .cons(DataSchemaExtC { t: 35 }),
                                 attype: Default::default(),
                                 title: Default::default(),
                                 titles: Default::default(),
@@ -3877,8 +3877,8 @@ mod tests {
                                 format: Default::default(),
                             }),
                             other: Cons::new_head(EventAffordanceExtA { f: 29 })
-                                .add(EventAffordanceExtB { l: 30 })
-                                .add(()),
+                                .cons(EventAffordanceExtB { l: 30 })
+                                .cons(()),
                             subscription: Default::default(),
                             data_response: Default::default(),
                             cancellation: Default::default(),
@@ -3892,10 +3892,10 @@ mod tests {
                     response: Some(ExpectedResponse {
                         content_type: "test".to_string(),
                         other: Cons::new_head(ExpectedResponseExtA { g: 37 })
-                            .add(ExpectedResponseExtB { n: 38 })
-                            .add(ExpectedResponseExtC { s: 39 })
+                            .cons(ExpectedResponseExtB { n: 38 })
+                            .cons(ExpectedResponseExtC { s: 39 })
                     }),
-                    other: Cons::new_head(()).add(FormExtB { m: 36 }).add(()),
+                    other: Cons::new_head(()).cons(FormExtB { m: 36 }).cons(()),
                     op: DefaultedFormOperations::Custom(vec![FormOperation::ReadAllProperties]),
                     content_type: Default::default(),
                     content_coding: Default::default(),
@@ -3910,8 +3910,8 @@ mod tests {
                         DataSchema {
                             subtype: Some(DataSchemaSubtype::Null),
                             other: Cons::new_head(DataSchemaExtA { h: 40 })
-                                .add(())
-                                .add(DataSchemaExtC { t: 41 }),
+                                .cons(())
+                                .cons(DataSchemaExtC { t: 41 }),
                             attype: Default::default(),
                             title: Default::default(),
                             titles: Default::default(),

--- a/src/builder/affordance.rs
+++ b/src/builder/affordance.rs
@@ -2423,11 +2423,9 @@ mod test {
                         "x".to_string(),
                         DataSchema {
                             subtype: Some(DataSchemaSubtype::Null),
-                            other: Cons::new_head(DataSchemaExtA { f: A(2) }).cons(
-                                DataSchemaExtB {
-                                    m: B("a".to_string())
-                                }
-                            ),
+                            other: Nil::cons(DataSchemaExtA { f: A(2) }).cons(DataSchemaExtB {
+                                m: B("a".to_string())
+                            }),
                             attype: Default::default(),
                             title: Default::default(),
                             titles: Default::default(),
@@ -2447,7 +2445,7 @@ mod test {
                 ),
                 forms: vec![Form {
                     href: "href".to_string(),
-                    other: Cons::new_head(FormExtA { d: A(3) }).cons(FormExtB {
+                    other: Nil::cons(FormExtA { d: A(3) }).cons(FormExtB {
                         k: B("c".to_string())
                     }),
                     op: Default::default(),
@@ -2459,7 +2457,7 @@ mod test {
                     response: Default::default(),
                     additional_responses: Default::default(),
                 }],
-                other: Cons::new_head(InteractionAffordanceExtA { a: A(1) }).cons(
+                other: Nil::cons(InteractionAffordanceExtA { a: A(1) }).cons(
                     InteractionAffordanceExtB {
                         g: B("b".to_string())
                     }
@@ -2506,7 +2504,7 @@ mod test {
             affordance,
             PropertyAffordance {
                 interaction: InteractionAffordance {
-                    other: Cons::new_head(InteractionAffordanceExtA { a: A(2) }).cons(
+                    other: Nil::cons(InteractionAffordanceExtA { a: A(2) }).cons(
                         InteractionAffordanceExtB {
                             g: B("b".to_string())
                         }
@@ -2516,11 +2514,9 @@ mod test {
                             "x".to_string(),
                             DataSchema {
                                 subtype: Some(DataSchemaSubtype::Null),
-                                other: Cons::new_head(DataSchemaExtA { f: A(3) }).cons(
-                                    DataSchemaExtB {
-                                        m: B("a".to_string())
-                                    }
-                                ),
+                                other: Nil::cons(DataSchemaExtA { f: A(3) }).cons(DataSchemaExtB {
+                                    m: B("a".to_string())
+                                }),
                                 attype: Default::default(),
                                 title: Default::default(),
                                 titles: Default::default(),
@@ -2548,7 +2544,7 @@ mod test {
                 data_schema: DataSchema {
                     title: Some("title".to_string()),
                     subtype: Some(DataSchemaSubtype::Null),
-                    other: Cons::new_head(DataSchemaExtA { f: A(4) }).cons(DataSchemaExtB {
+                    other: Nil::cons(DataSchemaExtA { f: A(4) }).cons(DataSchemaExtB {
                         m: B("d".to_string())
                     }),
                     attype: Default::default(),
@@ -2563,11 +2559,9 @@ mod test {
                     write_only: Default::default(),
                     format: Default::default(),
                 },
-                other: Cons::new_head(PropertyAffordanceExtA { b: A(1) }).cons(
-                    PropertyAffordanceExtB {
-                        h: B("c".to_string())
-                    }
-                ),
+                other: Nil::cons(PropertyAffordanceExtA { b: A(1) }).cons(PropertyAffordanceExtB {
+                    h: B("c".to_string())
+                }),
                 observable: Default::default(),
             }
         );
@@ -2614,11 +2608,9 @@ mod test {
                             "x".to_string(),
                             DataSchema {
                                 subtype: Some(DataSchemaSubtype::Null),
-                                other: Cons::new_head(DataSchemaExtA { f: A(2) }).cons(
-                                    DataSchemaExtB {
-                                        m: B("a".to_string())
-                                    }
-                                ),
+                                other: Nil::cons(DataSchemaExtA { f: A(2) }).cons(DataSchemaExtB {
+                                    m: B("a".to_string())
+                                }),
                                 attype: Default::default(),
                                 title: Default::default(),
                                 titles: Default::default(),
@@ -2636,7 +2628,7 @@ mod test {
                         .into_iter()
                         .collect()
                     ),
-                    other: Cons::new_head(InteractionAffordanceExtA { a: A(1) }).cons(
+                    other: Nil::cons(InteractionAffordanceExtA { a: A(1) }).cons(
                         InteractionAffordanceExtB {
                             g: B("b".to_string())
                         }
@@ -2649,7 +2641,7 @@ mod test {
                 },
                 subscription: Some(DataSchema {
                     subtype: Some(DataSchemaSubtype::Null),
-                    other: Cons::new_head(DataSchemaExtA { f: A(4) }).cons(DataSchemaExtB {
+                    other: Nil::cons(DataSchemaExtA { f: A(4) }).cons(DataSchemaExtB {
                         m: B("d".to_string())
                     }),
                     attype: Default::default(),
@@ -2665,7 +2657,7 @@ mod test {
                     write_only: Default::default(),
                     format: Default::default(),
                 }),
-                other: Cons::new_head(EventAffordanceExtA { c: A(3) }).cons(EventAffordanceExtB {
+                other: Nil::cons(EventAffordanceExtA { c: A(3) }).cons(EventAffordanceExtB {
                     j: B("c".to_string())
                 }),
                 data: Default::default(),
@@ -2716,11 +2708,9 @@ mod test {
                             "x".to_string(),
                             DataSchema {
                                 subtype: Some(DataSchemaSubtype::Null),
-                                other: Cons::new_head(DataSchemaExtA { f: A(2) }).cons(
-                                    DataSchemaExtB {
-                                        m: B("a".to_string())
-                                    }
-                                ),
+                                other: Nil::cons(DataSchemaExtA { f: A(2) }).cons(DataSchemaExtB {
+                                    m: B("a".to_string())
+                                }),
                                 attype: Default::default(),
                                 title: Default::default(),
                                 titles: Default::default(),
@@ -2738,7 +2728,7 @@ mod test {
                         .into_iter()
                         .collect()
                     ),
-                    other: Cons::new_head(InteractionAffordanceExtA { a: A(1) }).cons(
+                    other: Nil::cons(InteractionAffordanceExtA { a: A(1) }).cons(
                         InteractionAffordanceExtB {
                             g: B("b".to_string())
                         }
@@ -2751,7 +2741,7 @@ mod test {
                 },
                 input: Some(DataSchema {
                     subtype: Some(DataSchemaSubtype::Null),
-                    other: Cons::new_head(DataSchemaExtA { f: A(4) }).cons(DataSchemaExtB {
+                    other: Nil::cons(DataSchemaExtA { f: A(4) }).cons(DataSchemaExtB {
                         m: B("d".to_string())
                     }),
                     attype: Default::default(),
@@ -2767,11 +2757,9 @@ mod test {
                     write_only: Default::default(),
                     format: Default::default(),
                 }),
-                other: Cons::new_head(ActionAffordanceExtA { b: A(3) }).cons(
-                    ActionAffordanceExtB {
-                        i: B("c".to_string())
-                    }
-                ),
+                other: Nil::cons(ActionAffordanceExtA { b: A(3) }).cons(ActionAffordanceExtB {
+                    i: B("c".to_string())
+                }),
                 output: Default::default(),
                 safe: Default::default(),
                 idempotent: Default::default(),

--- a/src/builder/affordance.rs
+++ b/src/builder/affordance.rs
@@ -1854,9 +1854,9 @@ mod test {
                 .attype("attype1")
                 .attype("attype2")
                 .title("title")
-                .titles(|b| b.add("it", "title_it").add("en", "title_en"))
+                .titles(|b| b.cons("it", "title_it").cons("en", "title_en"))
                 .description("description")
-                .descriptions(|b| b.add("it", "description_it").add("en", "description_en"))
+                .descriptions(|b| b.cons("it", "description_it").cons("en", "description_en"))
                 .form(|b| b.href("form1_href").content_type("content_type"))
                 .form(|b| {
                     b.op(FormOperation::WriteProperty)
@@ -2423,9 +2423,11 @@ mod test {
                         "x".to_string(),
                         DataSchema {
                             subtype: Some(DataSchemaSubtype::Null),
-                            other: Cons::new_head(DataSchemaExtA { f: A(2) }).add(DataSchemaExtB {
-                                m: B("a".to_string())
-                            }),
+                            other: Cons::new_head(DataSchemaExtA { f: A(2) }).cons(
+                                DataSchemaExtB {
+                                    m: B("a".to_string())
+                                }
+                            ),
                             attype: Default::default(),
                             title: Default::default(),
                             titles: Default::default(),
@@ -2445,7 +2447,7 @@ mod test {
                 ),
                 forms: vec![Form {
                     href: "href".to_string(),
-                    other: Cons::new_head(FormExtA { d: A(3) }).add(FormExtB {
+                    other: Cons::new_head(FormExtA { d: A(3) }).cons(FormExtB {
                         k: B("c".to_string())
                     }),
                     op: Default::default(),
@@ -2457,7 +2459,7 @@ mod test {
                     response: Default::default(),
                     additional_responses: Default::default(),
                 }],
-                other: Cons::new_head(InteractionAffordanceExtA { a: A(1) }).add(
+                other: Cons::new_head(InteractionAffordanceExtA { a: A(1) }).cons(
                     InteractionAffordanceExtB {
                         g: B("b".to_string())
                     }
@@ -2504,7 +2506,7 @@ mod test {
             affordance,
             PropertyAffordance {
                 interaction: InteractionAffordance {
-                    other: Cons::new_head(InteractionAffordanceExtA { a: A(2) }).add(
+                    other: Cons::new_head(InteractionAffordanceExtA { a: A(2) }).cons(
                         InteractionAffordanceExtB {
                             g: B("b".to_string())
                         }
@@ -2514,7 +2516,7 @@ mod test {
                             "x".to_string(),
                             DataSchema {
                                 subtype: Some(DataSchemaSubtype::Null),
-                                other: Cons::new_head(DataSchemaExtA { f: A(3) }).add(
+                                other: Cons::new_head(DataSchemaExtA { f: A(3) }).cons(
                                     DataSchemaExtB {
                                         m: B("a".to_string())
                                     }
@@ -2546,7 +2548,7 @@ mod test {
                 data_schema: DataSchema {
                     title: Some("title".to_string()),
                     subtype: Some(DataSchemaSubtype::Null),
-                    other: Cons::new_head(DataSchemaExtA { f: A(4) }).add(DataSchemaExtB {
+                    other: Cons::new_head(DataSchemaExtA { f: A(4) }).cons(DataSchemaExtB {
                         m: B("d".to_string())
                     }),
                     attype: Default::default(),
@@ -2561,7 +2563,7 @@ mod test {
                     write_only: Default::default(),
                     format: Default::default(),
                 },
-                other: Cons::new_head(PropertyAffordanceExtA { b: A(1) }).add(
+                other: Cons::new_head(PropertyAffordanceExtA { b: A(1) }).cons(
                     PropertyAffordanceExtB {
                         h: B("c".to_string())
                     }
@@ -2612,7 +2614,7 @@ mod test {
                             "x".to_string(),
                             DataSchema {
                                 subtype: Some(DataSchemaSubtype::Null),
-                                other: Cons::new_head(DataSchemaExtA { f: A(2) }).add(
+                                other: Cons::new_head(DataSchemaExtA { f: A(2) }).cons(
                                     DataSchemaExtB {
                                         m: B("a".to_string())
                                     }
@@ -2634,7 +2636,7 @@ mod test {
                         .into_iter()
                         .collect()
                     ),
-                    other: Cons::new_head(InteractionAffordanceExtA { a: A(1) }).add(
+                    other: Cons::new_head(InteractionAffordanceExtA { a: A(1) }).cons(
                         InteractionAffordanceExtB {
                             g: B("b".to_string())
                         }
@@ -2647,7 +2649,7 @@ mod test {
                 },
                 subscription: Some(DataSchema {
                     subtype: Some(DataSchemaSubtype::Null),
-                    other: Cons::new_head(DataSchemaExtA { f: A(4) }).add(DataSchemaExtB {
+                    other: Cons::new_head(DataSchemaExtA { f: A(4) }).cons(DataSchemaExtB {
                         m: B("d".to_string())
                     }),
                     attype: Default::default(),
@@ -2663,7 +2665,7 @@ mod test {
                     write_only: Default::default(),
                     format: Default::default(),
                 }),
-                other: Cons::new_head(EventAffordanceExtA { c: A(3) }).add(EventAffordanceExtB {
+                other: Cons::new_head(EventAffordanceExtA { c: A(3) }).cons(EventAffordanceExtB {
                     j: B("c".to_string())
                 }),
                 data: Default::default(),
@@ -2714,7 +2716,7 @@ mod test {
                             "x".to_string(),
                             DataSchema {
                                 subtype: Some(DataSchemaSubtype::Null),
-                                other: Cons::new_head(DataSchemaExtA { f: A(2) }).add(
+                                other: Cons::new_head(DataSchemaExtA { f: A(2) }).cons(
                                     DataSchemaExtB {
                                         m: B("a".to_string())
                                     }
@@ -2736,7 +2738,7 @@ mod test {
                         .into_iter()
                         .collect()
                     ),
-                    other: Cons::new_head(InteractionAffordanceExtA { a: A(1) }).add(
+                    other: Cons::new_head(InteractionAffordanceExtA { a: A(1) }).cons(
                         InteractionAffordanceExtB {
                             g: B("b".to_string())
                         }
@@ -2749,7 +2751,7 @@ mod test {
                 },
                 input: Some(DataSchema {
                     subtype: Some(DataSchemaSubtype::Null),
-                    other: Cons::new_head(DataSchemaExtA { f: A(4) }).add(DataSchemaExtB {
+                    other: Cons::new_head(DataSchemaExtA { f: A(4) }).cons(DataSchemaExtB {
                         m: B("d".to_string())
                     }),
                     attype: Default::default(),
@@ -2765,9 +2767,11 @@ mod test {
                     write_only: Default::default(),
                     format: Default::default(),
                 }),
-                other: Cons::new_head(ActionAffordanceExtA { b: A(3) }).add(ActionAffordanceExtB {
-                    i: B("c".to_string())
-                }),
+                other: Cons::new_head(ActionAffordanceExtA { b: A(3) }).cons(
+                    ActionAffordanceExtB {
+                        i: B("c".to_string())
+                    }
+                ),
                 output: Default::default(),
                 safe: Default::default(),
                 idempotent: Default::default(),

--- a/src/builder/data_schema.rs
+++ b/src/builder/data_schema.rs
@@ -3665,7 +3665,7 @@ mod tests {
             data_schema,
             DataSchema {
                 title: Some("title".to_string()),
-                other: Cons::new_head(DataSchemaExtA { a: A(1) }).cons(DataSchemaExtB {
+                other: Nil::cons(DataSchemaExtA { a: A(1) }).cons(DataSchemaExtB {
                     d: B("hello".to_string())
                 }),
                 attype: Default::default(),
@@ -3712,7 +3712,7 @@ mod tests {
             data_schema,
             DataSchema {
                 title: Some("title".to_string()),
-                other: Cons::new_head(DataSchemaExtA { a: A(1) }).cons(DataSchemaExtB {
+                other: Nil::cons(DataSchemaExtA { a: A(1) }).cons(DataSchemaExtB {
                     d: B("hello".to_string())
                 }),
                 attype: Default::default(),
@@ -3727,7 +3727,7 @@ mod tests {
                 write_only: Default::default(),
                 format: Default::default(),
                 subtype: Some(DataSchemaSubtype::Array(ArraySchema {
-                    other: Cons::new_head(ArraySchemaExtA { b: A(2) }).cons(ArraySchemaExtB {
+                    other: Nil::cons(ArraySchemaExtA { b: A(2) }).cons(ArraySchemaExtB {
                         e: B("world".to_string())
                     }),
                     max_items: Some(10),
@@ -3773,22 +3773,20 @@ mod tests {
             data_schema,
             DataSchema {
                 title: Some("title".to_string()),
-                other: Cons::new_head(DataSchemaExtA { a: A(1) }).cons(DataSchemaExtB {
+                other: Nil::cons(DataSchemaExtA { a: A(1) }).cons(DataSchemaExtB {
                     d: B("hello".to_string())
                 }),
                 subtype: Some(DataSchemaSubtype::Object(ObjectSchema {
-                    other: Cons::new_head(ObjectSchemaExtA { c: A(2) }).cons(ObjectSchemaExtB {
+                    other: Nil::cons(ObjectSchemaExtA { c: A(2) }).cons(ObjectSchemaExtB {
                         f: B("world".to_string())
                     }),
                     properties: Some(
                         [(
                             "x".to_string(),
                             DataSchema {
-                                other: Cons::new_head(DataSchemaExtA { a: A(3) }).cons(
-                                    DataSchemaExtB {
-                                        d: B("other".to_string())
-                                    }
-                                ),
+                                other: Nil::cons(DataSchemaExtA { a: A(3) }).cons(DataSchemaExtB {
+                                    d: B("other".to_string())
+                                }),
                                 subtype: Some(DataSchemaSubtype::Null),
                                 attype: Default::default(),
                                 title: Default::default(),

--- a/src/builder/data_schema.rs
+++ b/src/builder/data_schema.rs
@@ -2626,9 +2626,9 @@ mod tests {
             .attype("attype1")
             .attype("attype2")
             .title("title")
-            .titles(|b| b.add("en", "title_en").add("it", "title_it"))
+            .titles(|b| b.cons("en", "title_en").cons("it", "title_it"))
             .description("description")
-            .descriptions(|b| b.add("en", "description_en").add("it", "description_it"))
+            .descriptions(|b| b.cons("en", "description_en").cons("it", "description_it"))
             .unit("cm")
             .format("format")
             .into();
@@ -2671,9 +2671,9 @@ mod tests {
             .enumeration(3u32)
             .attype("attype")
             .title("title")
-            .titles(|b| b.add("en", "title_en").add("it", "title_it"))
+            .titles(|b| b.cons("en", "title_en").cons("it", "title_it"))
             .description("description")
-            .descriptions(|b| b.add("en", "description_en").add("it", "description_it"))
+            .descriptions(|b| b.cons("en", "description_en").cons("it", "description_it"))
             .unit("cm")
             .format("format")
             .into();
@@ -3665,7 +3665,7 @@ mod tests {
             data_schema,
             DataSchema {
                 title: Some("title".to_string()),
-                other: Cons::new_head(DataSchemaExtA { a: A(1) }).add(DataSchemaExtB {
+                other: Cons::new_head(DataSchemaExtA { a: A(1) }).cons(DataSchemaExtB {
                     d: B("hello".to_string())
                 }),
                 attype: Default::default(),
@@ -3712,7 +3712,7 @@ mod tests {
             data_schema,
             DataSchema {
                 title: Some("title".to_string()),
-                other: Cons::new_head(DataSchemaExtA { a: A(1) }).add(DataSchemaExtB {
+                other: Cons::new_head(DataSchemaExtA { a: A(1) }).cons(DataSchemaExtB {
                     d: B("hello".to_string())
                 }),
                 attype: Default::default(),
@@ -3727,7 +3727,7 @@ mod tests {
                 write_only: Default::default(),
                 format: Default::default(),
                 subtype: Some(DataSchemaSubtype::Array(ArraySchema {
-                    other: Cons::new_head(ArraySchemaExtA { b: A(2) }).add(ArraySchemaExtB {
+                    other: Cons::new_head(ArraySchemaExtA { b: A(2) }).cons(ArraySchemaExtB {
                         e: B("world".to_string())
                     }),
                     max_items: Some(10),
@@ -3773,18 +3773,18 @@ mod tests {
             data_schema,
             DataSchema {
                 title: Some("title".to_string()),
-                other: Cons::new_head(DataSchemaExtA { a: A(1) }).add(DataSchemaExtB {
+                other: Cons::new_head(DataSchemaExtA { a: A(1) }).cons(DataSchemaExtB {
                     d: B("hello".to_string())
                 }),
                 subtype: Some(DataSchemaSubtype::Object(ObjectSchema {
-                    other: Cons::new_head(ObjectSchemaExtA { c: A(2) }).add(ObjectSchemaExtB {
+                    other: Cons::new_head(ObjectSchemaExtA { c: A(2) }).cons(ObjectSchemaExtB {
                         f: B("world".to_string())
                     }),
                     properties: Some(
                         [(
                             "x".to_string(),
                             DataSchema {
-                                other: Cons::new_head(DataSchemaExtA { a: A(3) }).add(
+                                other: Cons::new_head(DataSchemaExtA { a: A(3) }).cons(
                                     DataSchemaExtB {
                                         d: B("other".to_string())
                                     }

--- a/src/extend.rs
+++ b/src/extend.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::hlist::{Cons, HList, Nil};
+use crate::hlist::{Cons, Nil};
 
 pub trait ExtendablePiece: Serialize + for<'a> Deserialize<'a> {}
 
@@ -81,10 +81,7 @@ impl<T> Extend<T> for Nil {
     }
 }
 
-impl<T, U> Extendable for Cons<T, U>
-where
-    Cons<T, U>: HList,
-{
+impl<T, U> Extendable for Cons<T, U> {
     type Empty = Nil;
 
     fn empty() -> Self::Empty {

--- a/src/extend.rs
+++ b/src/extend.rs
@@ -77,7 +77,7 @@ impl<T> Extend<T> for Nil {
     type Target = Cons<T, Nil>;
 
     fn ext(self, t: T) -> Self::Target {
-        Cons::new_head(t)
+        Nil::cons(t)
     }
 }
 

--- a/src/extend.rs
+++ b/src/extend.rs
@@ -93,6 +93,6 @@ impl<T, U, V> Extend<T> for Cons<U, V> {
     type Target = Cons<T, Cons<U, V>>;
 
     fn ext(self, t: T) -> Self::Target {
-        self.add(t)
+        self.cons(t)
     }
 }

--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -11,21 +11,6 @@ pub struct Cons<T, U = Nil> {
     pub(crate) tail: U,
 }
 
-pub(crate) trait HList: Sized {
-    const SIZE: usize;
-}
-
-impl HList for Nil {
-    const SIZE: usize = 0;
-}
-
-impl<T, U> HList for Cons<T, U>
-where
-    U: HList,
-{
-    const SIZE: usize = U::SIZE + 1;
-}
-
 impl<T> Cons<T, Nil> {
     #[inline]
     pub(crate) fn new_head(head: T) -> Self {

--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -6,14 +6,14 @@ pub struct Nil;
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Cons<T, U = Nil> {
     #[serde(flatten)]
-    pub(crate) head: T,
+    pub head: T,
     #[serde(flatten)]
-    pub(crate) tail: U,
+    pub tail: U,
 }
 
 impl Nil {
     #[inline]
-    pub(crate) fn cons<T>(value: T) -> Cons<T, Nil> {
+    pub fn cons<T>(value: T) -> Cons<T, Nil> {
         Cons {
             head: value,
             tail: Nil,
@@ -23,7 +23,7 @@ impl Nil {
 
 impl<T, U> Cons<T, U> {
     #[inline]
-    pub(crate) fn cons<V>(self, value: V) -> Cons<V, Self> {
+    pub fn cons<V>(self, value: V) -> Cons<V, Self> {
         Cons {
             head: value,
             tail: self,

--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -20,7 +20,7 @@ impl<T> Cons<T, Nil> {
 
 impl<T, U> Cons<T, U> {
     #[inline]
-    pub(crate) fn add<V>(self, value: V) -> Cons<V, Self> {
+    pub(crate) fn cons<V>(self, value: V) -> Cons<V, Self> {
         Cons {
             head: value,
             tail: self,
@@ -211,17 +211,19 @@ mod tests {
         #[derive(Debug, PartialEq)]
         struct C(String);
 
-        let list = Cons::new_head(A(42)).add(B(1.234)).add(C("C".to_string()));
+        let list = Cons::new_head(A(42))
+            .cons(B(1.234))
+            .cons(C("C".to_string()));
 
         assert_eq!(
             list.split_head(),
-            (C("C".to_string()), Cons::new_head(A(42)).add(B(1.234))),
+            (C("C".to_string()), Cons::new_head(A(42)).cons(B(1.234))),
         )
     }
 
     #[test]
     fn chain() {
-        let list = Cons::new_head("A").add(2).add("C".to_string());
+        let list = Cons::new_head("A").cons(2).cons("C".to_string());
 
         assert_eq!(
             list,
@@ -271,7 +273,7 @@ mod tests {
 
         let value = serde_json::to_value(A {
             a: 42,
-            b: Cons::new_head(B { foo: 42 }).add(C { bar: "42" }),
+            b: Cons::new_head(B { foo: 42 }).cons(C { bar: "42" }),
         })
         .unwrap();
         assert_eq!(value.get("a").unwrap(), &Value::Number(42.into()));
@@ -320,14 +322,14 @@ mod tests {
         struct C(String);
 
         let list = Cons::new_head(A(42))
-            .add(B(1.234))
-            .add(C("hello".to_string()));
+            .cons(B(1.234))
+            .cons(C("hello".to_string()));
 
         assert_eq!(
             list.to_ref(),
             Cons::new_head(&A(42))
-                .add(&B(1.234))
-                .add(&C("hello".to_string())),
+                .cons(&B(1.234))
+                .cons(&C("hello".to_string())),
         )
     }
 
@@ -343,14 +345,14 @@ mod tests {
         struct C(String);
 
         let mut list = Cons::new_head(A(42))
-            .add(B(1.234))
-            .add(C("hello".to_string()));
+            .cons(B(1.234))
+            .cons(C("hello".to_string()));
 
         assert_eq!(
             list.to_mut(),
             Cons::new_head(&mut A(42))
-                .add(&mut B(1.234))
-                .add(&mut C("hello".to_string())),
+                .cons(&mut B(1.234))
+                .cons(&mut C("hello".to_string())),
         )
     }
 
@@ -366,12 +368,12 @@ mod tests {
         struct C(String);
 
         let list = Cons::new_head(A(42))
-            .add(B(1.234))
-            .add(C("hello".to_string()));
+            .cons(B(1.234))
+            .cons(C("hello".to_string()));
 
         let (last, init) = list.split_last();
         assert_eq!(last, A(42));
-        assert_eq!(init, Cons::new_head(B(1.234)).add(C("hello".to_string())));
+        assert_eq!(init, Cons::new_head(B(1.234)).cons(C("hello".to_string())));
 
         let (last, init) = init.split_last();
         assert_eq!(last, B(1.234));
@@ -394,14 +396,14 @@ mod tests {
         struct C(String);
 
         let list = Cons::new_head(A(42))
-            .add(B(1.234))
-            .add(C("hello".to_string()));
+            .cons(B(1.234))
+            .cons(C("hello".to_string()));
 
         assert_eq!(
             list.reverse(),
             Cons::new_head(C("hello".to_string()))
-                .add(B(1.234))
-                .add(A(42)),
+                .cons(B(1.234))
+                .cons(A(42)),
         )
     }
 }

--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -11,10 +11,13 @@ pub struct Cons<T, U = Nil> {
     pub(crate) tail: U,
 }
 
-impl<T> Cons<T, Nil> {
+impl Nil {
     #[inline]
-    pub(crate) fn new_head(head: T) -> Self {
-        Cons { head, tail: Nil {} }
+    pub(crate) fn cons<T>(value: T) -> Cons<T, Nil> {
+        Cons {
+            head: value,
+            tail: Nil,
+        }
     }
 }
 
@@ -211,19 +214,17 @@ mod tests {
         #[derive(Debug, PartialEq)]
         struct C(String);
 
-        let list = Cons::new_head(A(42))
-            .cons(B(1.234))
-            .cons(C("C".to_string()));
+        let list = Nil::cons(A(42)).cons(B(1.234)).cons(C("C".to_string()));
 
         assert_eq!(
             list.split_head(),
-            (C("C".to_string()), Cons::new_head(A(42)).cons(B(1.234))),
+            (C("C".to_string()), Nil::cons(A(42)).cons(B(1.234))),
         )
     }
 
     #[test]
     fn chain() {
-        let list = Cons::new_head("A").cons(2).cons("C".to_string());
+        let list = Nil::cons("A").cons(2).cons("C".to_string());
 
         assert_eq!(
             list,
@@ -273,7 +274,7 @@ mod tests {
 
         let value = serde_json::to_value(A {
             a: 42,
-            b: Cons::new_head(B { foo: 42 }).cons(C { bar: "42" }),
+            b: Nil::cons(B { foo: 42 }).cons(C { bar: "42" }),
         })
         .unwrap();
         assert_eq!(value.get("a").unwrap(), &Value::Number(42.into()));
@@ -321,13 +322,11 @@ mod tests {
         #[derive(Debug, PartialEq)]
         struct C(String);
 
-        let list = Cons::new_head(A(42))
-            .cons(B(1.234))
-            .cons(C("hello".to_string()));
+        let list = Nil::cons(A(42)).cons(B(1.234)).cons(C("hello".to_string()));
 
         assert_eq!(
             list.to_ref(),
-            Cons::new_head(&A(42))
+            Nil::cons(&A(42))
                 .cons(&B(1.234))
                 .cons(&C("hello".to_string())),
         )
@@ -344,13 +343,11 @@ mod tests {
         #[derive(Debug, PartialEq)]
         struct C(String);
 
-        let mut list = Cons::new_head(A(42))
-            .cons(B(1.234))
-            .cons(C("hello".to_string()));
+        let mut list = Nil::cons(A(42)).cons(B(1.234)).cons(C("hello".to_string()));
 
         assert_eq!(
             list.to_mut(),
-            Cons::new_head(&mut A(42))
+            Nil::cons(&mut A(42))
                 .cons(&mut B(1.234))
                 .cons(&mut C("hello".to_string())),
         )
@@ -367,17 +364,15 @@ mod tests {
         #[derive(Debug, PartialEq)]
         struct C(String);
 
-        let list = Cons::new_head(A(42))
-            .cons(B(1.234))
-            .cons(C("hello".to_string()));
+        let list = Nil::cons(A(42)).cons(B(1.234)).cons(C("hello".to_string()));
 
         let (last, init) = list.split_last();
         assert_eq!(last, A(42));
-        assert_eq!(init, Cons::new_head(B(1.234)).cons(C("hello".to_string())));
+        assert_eq!(init, Nil::cons(B(1.234)).cons(C("hello".to_string())));
 
         let (last, init) = init.split_last();
         assert_eq!(last, B(1.234));
-        assert_eq!(init, Cons::new_head(C("hello".to_string())));
+        assert_eq!(init, Nil::cons(C("hello".to_string())));
 
         let (last, init) = init.split_last();
         assert_eq!(last, C("hello".to_string()));
@@ -395,15 +390,11 @@ mod tests {
         #[derive(Debug, PartialEq)]
         struct C(String);
 
-        let list = Cons::new_head(A(42))
-            .cons(B(1.234))
-            .cons(C("hello".to_string()));
+        let list = Nil::cons(A(42)).cons(B(1.234)).cons(C("hello".to_string()));
 
         assert_eq!(
             list.reverse(),
-            Cons::new_head(C("hello".to_string()))
-                .cons(B(1.234))
-                .cons(A(42)),
+            Nil::cons(C("hello".to_string())).cons(B(1.234)).cons(A(42)),
         )
     }
 }

--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -129,16 +129,21 @@ mod tests {
 
     #[test]
     fn split_head() {
-        let list = Cons::new_head("A").add(2).add("C".to_string());
+        #[derive(Debug, PartialEq)]
+        struct A(i32);
 
-        let ref_list = list.to_ref();
+        #[derive(Debug, PartialEq)]
+        struct B(f32);
 
-        let (head, tail) = ref_list.split_head();
-        assert_eq!(head, &"C".to_string());
-        let (head, tail) = tail.split_head();
-        assert_eq!(head, &2);
-        let (head, _tail) = tail.split_head();
-        assert_eq!(head, &"A");
+        #[derive(Debug, PartialEq)]
+        struct C(String);
+
+        let list = Cons::new_head(A(42)).add(B(1.234)).add(C("C".to_string()));
+
+        assert_eq!(
+            list.split_head(),
+            (C("C".to_string()), Cons::new_head(A(42)).add(B(1.234))),
+        )
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,5 +11,5 @@
 
 pub mod builder;
 pub mod extend;
-mod hlist;
+pub mod hlist;
 pub mod thing;

--- a/src/thing.rs
+++ b/src/thing.rs
@@ -1613,18 +1613,18 @@ mod test {
                     "prop".to_string(),
                     PropertyAffordance {
                         interaction: InteractionAffordance {
-                            other: Cons::new_head(IntAffExtA { b: A(1) }),
+                            other: Nil::cons(IntAffExtA { b: A(1) }),
                             ..Default::default()
                         },
                         data_schema: DataSchema {
                             subtype: Some(DataSchemaSubtype::Array(ArraySchema {
-                                other: Cons::new_head(ArraySchemaExtA { j: A(2) }),
+                                other: Nil::cons(ArraySchemaExtA { j: A(2) }),
                                 ..Default::default()
                             })),
-                            other: Cons::new_head(DataSchemaExtA { h: A(3) }),
+                            other: Nil::cons(DataSchemaExtA { h: A(3) }),
                             ..Default::default()
                         },
-                        other: Cons::new_head(PropAffExtA { d: A(4) }),
+                        other: Nil::cons(PropAffExtA { d: A(4) }),
                         ..Default::default()
                     },
                 )]
@@ -1636,19 +1636,19 @@ mod test {
                     "action".to_string(),
                     ActionAffordance {
                         interaction: InteractionAffordance {
-                            other: Cons::new_head(IntAffExtA { b: A(5) }),
+                            other: Nil::cons(IntAffExtA { b: A(5) }),
                             ..Default::default()
                         },
                         input: Some(DataSchema {
                             subtype: Some(DataSchemaSubtype::Object(ObjectSchema {
-                                other: Cons::new_head(ObjectSchemaExtA { i: A(6) }),
+                                other: Nil::cons(ObjectSchemaExtA { i: A(6) }),
                                 ..Default::default()
                             })),
-                            other: Cons::new_head(DataSchemaExtA { h: A(7) }),
+                            other: Nil::cons(DataSchemaExtA { h: A(7) }),
                             ..Default::default()
                         }),
                         output: Some(DataSchema::default()),
-                        other: Cons::new_head(ActionAffExtA { c: A(8) }),
+                        other: Nil::cons(ActionAffExtA { c: A(8) }),
                         ..Default::default()
                     },
                 )]
@@ -1659,7 +1659,7 @@ mod test {
                 [(
                     "event".to_string(),
                     EventAffordance {
-                        other: Cons::new_head(EventAffExtA { e: A(9) }),
+                        other: Nil::cons(EventAffExtA { e: A(9) }),
                         ..Default::default()
                     },
                 )]
@@ -1668,13 +1668,13 @@ mod test {
             ),
             forms: Some(vec![Form {
                 response: Some(ExpectedResponse {
-                    other: Cons::new_head(RespExtA { g: A(10) }),
+                    other: Nil::cons(RespExtA { g: A(10) }),
                     ..Default::default()
                 }),
-                other: Cons::new_head(FormExtA { f: A(11) }),
+                other: Nil::cons(FormExtA { f: A(11) }),
                 ..Default::default()
             }]),
-            other: Cons::new_head(ThingExtA { a: A(12) }),
+            other: Nil::cons(ThingExtA { a: A(12) }),
             ..Default::default()
         };
 
@@ -1811,22 +1811,20 @@ mod test {
                     "prop".to_string(),
                     PropertyAffordance {
                         interaction: InteractionAffordance {
-                            other: Cons::new_head(IntAffExtA { b: A(1) })
-                                .cons(IntAffExtB { l: A(2) }),
+                            other: Nil::cons(IntAffExtA { b: A(1) }).cons(IntAffExtB { l: A(2) }),
                             ..Default::default()
                         },
                         data_schema: DataSchema {
                             subtype: Some(DataSchemaSubtype::Array(ArraySchema {
-                                other: Cons::new_head(ArraySchemaExtA { j: A(3) })
+                                other: Nil::cons(ArraySchemaExtA { j: A(3) })
                                     .cons(ArraySchemaExtB { t: A(4) }),
                                 ..Default::default()
                             })),
-                            other: Cons::new_head(DataSchemaExtA { h: A(5) })
+                            other: Nil::cons(DataSchemaExtA { h: A(5) })
                                 .cons(DataSchemaExtB { r: A(6) }),
                             ..Default::default()
                         },
-                        other: Cons::new_head(PropAffExtA { d: A(7) })
-                            .cons(PropAffExtB { n: A(8) }),
+                        other: Nil::cons(PropAffExtA { d: A(7) }).cons(PropAffExtB { n: A(8) }),
                         ..Default::default()
                     },
                 )]
@@ -1838,22 +1836,21 @@ mod test {
                     "action".to_string(),
                     ActionAffordance {
                         interaction: InteractionAffordance {
-                            other: Cons::new_head(IntAffExtA { b: A(9) })
-                                .cons(IntAffExtB { l: A(10) }),
+                            other: Nil::cons(IntAffExtA { b: A(9) }).cons(IntAffExtB { l: A(10) }),
                             ..Default::default()
                         },
                         input: Some(DataSchema {
                             subtype: Some(DataSchemaSubtype::Object(ObjectSchema {
-                                other: Cons::new_head(ObjectSchemaExtA { i: A(11) })
+                                other: Nil::cons(ObjectSchemaExtA { i: A(11) })
                                     .cons(ObjectSchemaExtB { s: A(12) }),
                                 ..Default::default()
                             })),
-                            other: Cons::new_head(DataSchemaExtA { h: A(13) })
+                            other: Nil::cons(DataSchemaExtA { h: A(13) })
                                 .cons(DataSchemaExtB { r: A(14) }),
                             ..Default::default()
                         }),
                         output: Some(DataSchema::default()),
-                        other: Cons::new_head(ActionAffExtA { c: A(15) })
+                        other: Nil::cons(ActionAffExtA { c: A(15) })
                             .cons(ActionAffExtB { m: A(16) }),
                         ..Default::default()
                     },
@@ -1865,8 +1862,7 @@ mod test {
                 [(
                     "event".to_string(),
                     EventAffordance {
-                        other: Cons::new_head(EventAffExtA { e: A(17) })
-                            .cons(EventAffExtB { o: A(18) }),
+                        other: Nil::cons(EventAffExtA { e: A(17) }).cons(EventAffExtB { o: A(18) }),
                         ..Default::default()
                     },
                 )]
@@ -1875,13 +1871,13 @@ mod test {
             ),
             forms: Some(vec![Form {
                 response: Some(ExpectedResponse {
-                    other: Cons::new_head(RespExtA { g: A(19) }).cons(RespExtB { q: A(20) }),
+                    other: Nil::cons(RespExtA { g: A(19) }).cons(RespExtB { q: A(20) }),
                     ..Default::default()
                 }),
-                other: Cons::new_head(FormExtA { f: A(21) }).cons(FormExtB { p: A(22) }),
+                other: Nil::cons(FormExtA { f: A(21) }).cons(FormExtB { p: A(22) }),
                 ..Default::default()
             }]),
-            other: Cons::new_head(ThingExtA { a: A(23) }).cons(ThingExtB { k: A(24) }),
+            other: Nil::cons(ThingExtA { a: A(23) }).cons(ThingExtB { k: A(24) }),
             ..Default::default()
         };
 
@@ -2017,24 +2013,24 @@ mod test {
                     "prop".to_string(),
                     PropertyAffordance {
                         interaction: InteractionAffordance {
-                            other: Cons::new_head(IntAffExtA { b: A(1) })
+                            other: Nil::cons(IntAffExtA { b: A(1) })
                                 .cons(())
                                 .cons(IntAffExtB { l: A(2) }),
                             ..Default::default()
                         },
                         data_schema: DataSchema {
                             subtype: Some(DataSchemaSubtype::Array(ArraySchema {
-                                other: Cons::new_head(ArraySchemaExtA { j: A(3) })
+                                other: Nil::cons(ArraySchemaExtA { j: A(3) })
                                     .cons(())
                                     .cons(ArraySchemaExtB { t: A(4) }),
                                 ..Default::default()
                             })),
-                            other: Cons::new_head(DataSchemaExtA { h: A(5) })
+                            other: Nil::cons(DataSchemaExtA { h: A(5) })
                                 .cons(())
                                 .cons(DataSchemaExtB { r: A(6) }),
                             ..Default::default()
                         },
-                        other: Cons::new_head(PropAffExtA { d: A(7) })
+                        other: Nil::cons(PropAffExtA { d: A(7) })
                             .cons(())
                             .cons(PropAffExtB { n: A(8) }),
                         ..Default::default()
@@ -2049,32 +2045,32 @@ mod test {
                     ActionAffordance {
                         interaction: InteractionAffordance {
                             forms: vec![Form {
-                                other: Cons::new_head(FormExtA::default())
+                                other: Nil::cons(FormExtA::default())
                                     .cons(HttpForm {
                                         method_name: Some(HttpMethod::Put),
                                     })
                                     .cons(FormExtB::default()),
                                 ..Default::default()
                             }],
-                            other: Cons::new_head(IntAffExtA { b: A(9) })
+                            other: Nil::cons(IntAffExtA { b: A(9) })
                                 .cons(())
                                 .cons(IntAffExtB { l: A(10) }),
                             ..Default::default()
                         },
                         input: Some(DataSchema {
                             subtype: Some(DataSchemaSubtype::Object(ObjectSchema {
-                                other: Cons::new_head(ObjectSchemaExtA { i: A(11) })
+                                other: Nil::cons(ObjectSchemaExtA { i: A(11) })
                                     .cons(())
                                     .cons(ObjectSchemaExtB { s: A(12) }),
                                 ..Default::default()
                             })),
-                            other: Cons::new_head(DataSchemaExtA { h: A(13) })
+                            other: Nil::cons(DataSchemaExtA { h: A(13) })
                                 .cons(())
                                 .cons(DataSchemaExtB { r: A(14) }),
                             ..Default::default()
                         }),
                         output: Some(DataSchema::default()),
-                        other: Cons::new_head(ActionAffExtA { c: A(15) })
+                        other: Nil::cons(ActionAffExtA { c: A(15) })
                             .cons(())
                             .cons(ActionAffExtB { m: A(16) }),
                         ..Default::default()
@@ -2087,7 +2083,7 @@ mod test {
                 [(
                     "event".to_string(),
                     EventAffordance {
-                        other: Cons::new_head(EventAffExtA { e: A(17) })
+                        other: Nil::cons(EventAffExtA { e: A(17) })
                             .cons(())
                             .cons(EventAffExtB { o: A(18) }),
                         ..Default::default()
@@ -2098,7 +2094,7 @@ mod test {
             ),
             forms: Some(vec![Form {
                 response: Some(ExpectedResponse {
-                    other: Cons::new_head(RespExtA { g: A(19) })
+                    other: Nil::cons(RespExtA { g: A(19) })
                         .cons(HttpResponse {
                             headers: vec![HttpMessageHeader {
                                 field_name: Some("hello".to_string()),
@@ -2109,14 +2105,14 @@ mod test {
                         .cons(RespExtB { q: A(20) }),
                     ..Default::default()
                 }),
-                other: Cons::new_head(FormExtA { f: A(21) })
+                other: Nil::cons(FormExtA { f: A(21) })
                     .cons(HttpForm {
                         method_name: Some(HttpMethod::Get),
                     })
                     .cons(FormExtB { p: A(22) }),
                 ..Default::default()
             }]),
-            other: Cons::new_head(ThingExtA { a: A(23) })
+            other: Nil::cons(ThingExtA { a: A(23) })
                 .cons(HttpThing {})
                 .cons(ThingExtB { k: A(24) }),
             ..Default::default()

--- a/src/thing.rs
+++ b/src/thing.rs
@@ -1812,20 +1812,21 @@ mod test {
                     PropertyAffordance {
                         interaction: InteractionAffordance {
                             other: Cons::new_head(IntAffExtA { b: A(1) })
-                                .add(IntAffExtB { l: A(2) }),
+                                .cons(IntAffExtB { l: A(2) }),
                             ..Default::default()
                         },
                         data_schema: DataSchema {
                             subtype: Some(DataSchemaSubtype::Array(ArraySchema {
                                 other: Cons::new_head(ArraySchemaExtA { j: A(3) })
-                                    .add(ArraySchemaExtB { t: A(4) }),
+                                    .cons(ArraySchemaExtB { t: A(4) }),
                                 ..Default::default()
                             })),
                             other: Cons::new_head(DataSchemaExtA { h: A(5) })
-                                .add(DataSchemaExtB { r: A(6) }),
+                                .cons(DataSchemaExtB { r: A(6) }),
                             ..Default::default()
                         },
-                        other: Cons::new_head(PropAffExtA { d: A(7) }).add(PropAffExtB { n: A(8) }),
+                        other: Cons::new_head(PropAffExtA { d: A(7) })
+                            .cons(PropAffExtB { n: A(8) }),
                         ..Default::default()
                     },
                 )]
@@ -1838,22 +1839,22 @@ mod test {
                     ActionAffordance {
                         interaction: InteractionAffordance {
                             other: Cons::new_head(IntAffExtA { b: A(9) })
-                                .add(IntAffExtB { l: A(10) }),
+                                .cons(IntAffExtB { l: A(10) }),
                             ..Default::default()
                         },
                         input: Some(DataSchema {
                             subtype: Some(DataSchemaSubtype::Object(ObjectSchema {
                                 other: Cons::new_head(ObjectSchemaExtA { i: A(11) })
-                                    .add(ObjectSchemaExtB { s: A(12) }),
+                                    .cons(ObjectSchemaExtB { s: A(12) }),
                                 ..Default::default()
                             })),
                             other: Cons::new_head(DataSchemaExtA { h: A(13) })
-                                .add(DataSchemaExtB { r: A(14) }),
+                                .cons(DataSchemaExtB { r: A(14) }),
                             ..Default::default()
                         }),
                         output: Some(DataSchema::default()),
                         other: Cons::new_head(ActionAffExtA { c: A(15) })
-                            .add(ActionAffExtB { m: A(16) }),
+                            .cons(ActionAffExtB { m: A(16) }),
                         ..Default::default()
                     },
                 )]
@@ -1865,7 +1866,7 @@ mod test {
                     "event".to_string(),
                     EventAffordance {
                         other: Cons::new_head(EventAffExtA { e: A(17) })
-                            .add(EventAffExtB { o: A(18) }),
+                            .cons(EventAffExtB { o: A(18) }),
                         ..Default::default()
                     },
                 )]
@@ -1874,13 +1875,13 @@ mod test {
             ),
             forms: Some(vec![Form {
                 response: Some(ExpectedResponse {
-                    other: Cons::new_head(RespExtA { g: A(19) }).add(RespExtB { q: A(20) }),
+                    other: Cons::new_head(RespExtA { g: A(19) }).cons(RespExtB { q: A(20) }),
                     ..Default::default()
                 }),
-                other: Cons::new_head(FormExtA { f: A(21) }).add(FormExtB { p: A(22) }),
+                other: Cons::new_head(FormExtA { f: A(21) }).cons(FormExtB { p: A(22) }),
                 ..Default::default()
             }]),
-            other: Cons::new_head(ThingExtA { a: A(23) }).add(ThingExtB { k: A(24) }),
+            other: Cons::new_head(ThingExtA { a: A(23) }).cons(ThingExtB { k: A(24) }),
             ..Default::default()
         };
 
@@ -2017,25 +2018,25 @@ mod test {
                     PropertyAffordance {
                         interaction: InteractionAffordance {
                             other: Cons::new_head(IntAffExtA { b: A(1) })
-                                .add(())
-                                .add(IntAffExtB { l: A(2) }),
+                                .cons(())
+                                .cons(IntAffExtB { l: A(2) }),
                             ..Default::default()
                         },
                         data_schema: DataSchema {
                             subtype: Some(DataSchemaSubtype::Array(ArraySchema {
                                 other: Cons::new_head(ArraySchemaExtA { j: A(3) })
-                                    .add(())
-                                    .add(ArraySchemaExtB { t: A(4) }),
+                                    .cons(())
+                                    .cons(ArraySchemaExtB { t: A(4) }),
                                 ..Default::default()
                             })),
                             other: Cons::new_head(DataSchemaExtA { h: A(5) })
-                                .add(())
-                                .add(DataSchemaExtB { r: A(6) }),
+                                .cons(())
+                                .cons(DataSchemaExtB { r: A(6) }),
                             ..Default::default()
                         },
                         other: Cons::new_head(PropAffExtA { d: A(7) })
-                            .add(())
-                            .add(PropAffExtB { n: A(8) }),
+                            .cons(())
+                            .cons(PropAffExtB { n: A(8) }),
                         ..Default::default()
                     },
                 )]
@@ -2049,33 +2050,33 @@ mod test {
                         interaction: InteractionAffordance {
                             forms: vec![Form {
                                 other: Cons::new_head(FormExtA::default())
-                                    .add(HttpForm {
+                                    .cons(HttpForm {
                                         method_name: Some(HttpMethod::Put),
                                     })
-                                    .add(FormExtB::default()),
+                                    .cons(FormExtB::default()),
                                 ..Default::default()
                             }],
                             other: Cons::new_head(IntAffExtA { b: A(9) })
-                                .add(())
-                                .add(IntAffExtB { l: A(10) }),
+                                .cons(())
+                                .cons(IntAffExtB { l: A(10) }),
                             ..Default::default()
                         },
                         input: Some(DataSchema {
                             subtype: Some(DataSchemaSubtype::Object(ObjectSchema {
                                 other: Cons::new_head(ObjectSchemaExtA { i: A(11) })
-                                    .add(())
-                                    .add(ObjectSchemaExtB { s: A(12) }),
+                                    .cons(())
+                                    .cons(ObjectSchemaExtB { s: A(12) }),
                                 ..Default::default()
                             })),
                             other: Cons::new_head(DataSchemaExtA { h: A(13) })
-                                .add(())
-                                .add(DataSchemaExtB { r: A(14) }),
+                                .cons(())
+                                .cons(DataSchemaExtB { r: A(14) }),
                             ..Default::default()
                         }),
                         output: Some(DataSchema::default()),
                         other: Cons::new_head(ActionAffExtA { c: A(15) })
-                            .add(())
-                            .add(ActionAffExtB { m: A(16) }),
+                            .cons(())
+                            .cons(ActionAffExtB { m: A(16) }),
                         ..Default::default()
                     },
                 )]
@@ -2087,8 +2088,8 @@ mod test {
                     "event".to_string(),
                     EventAffordance {
                         other: Cons::new_head(EventAffExtA { e: A(17) })
-                            .add(())
-                            .add(EventAffExtB { o: A(18) }),
+                            .cons(())
+                            .cons(EventAffExtB { o: A(18) }),
                         ..Default::default()
                     },
                 )]
@@ -2098,26 +2099,26 @@ mod test {
             forms: Some(vec![Form {
                 response: Some(ExpectedResponse {
                     other: Cons::new_head(RespExtA { g: A(19) })
-                        .add(HttpResponse {
+                        .cons(HttpResponse {
                             headers: vec![HttpMessageHeader {
                                 field_name: Some("hello".to_string()),
                                 field_value: Some("world".to_string()),
                             }],
                             status_code_value: Some(200),
                         })
-                        .add(RespExtB { q: A(20) }),
+                        .cons(RespExtB { q: A(20) }),
                     ..Default::default()
                 }),
                 other: Cons::new_head(FormExtA { f: A(21) })
-                    .add(HttpForm {
+                    .cons(HttpForm {
                         method_name: Some(HttpMethod::Get),
                     })
-                    .add(FormExtB { p: A(22) }),
+                    .cons(FormExtB { p: A(22) }),
                 ..Default::default()
             }]),
             other: Cons::new_head(ThingExtA { a: A(23) })
-                .add(HttpThing {})
-                .add(ThingExtB { k: A(24) }),
+                .cons(HttpThing {})
+                .cons(ThingExtB { k: A(24) }),
             ..Default::default()
         };
 


### PR DESCRIPTION
This is meant to be _private_ because it is extremely subject to change, and it is an implementation detail (sort of). However, we need to directly manipulate HLists from other wot crates, therefore we need to make things public.

We should also provide ad documentation that explains that every use of HLists will probably break every version of wot-td, in unpredictable ways.