### PR TITLE
feat: Make the {builders}::other public

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -62,7 +62,7 @@ pub struct ThingBuilder<Other: ExtendableThing, Status> {
     security_definitions: Vec<(String, SecurityScheme)>,
     profile: Vec<String>,
     schema_definitions: HashMap<String, DataSchemaFromOther<Other>>,
-    other: Other,
+    pub other: Other,
     _marker: PhantomData<Status>,
 }
 
@@ -1458,7 +1458,7 @@ pub struct FormBuilder<Other: ExtendableThing, Href, OtherForm> {
     scopes: Option<Vec<String>>,
     response: Option<ExpectedResponse<Other::ExpectedResponse>>,
     additional_responses: Vec<AdditionalExpectedResponse>,
-    other: OtherForm,
+    pub other: OtherForm,
     _marker: PhantomData<fn() -> Other>,
 }
 

--- a/src/builder/affordance.rs
+++ b/src/builder/affordance.rs
@@ -61,7 +61,7 @@ pub trait BuildableInteractionAffordance<Other: ExtendableThing> {
 pub struct PartialInteractionAffordanceBuilder<Other: ExtendableThing, OtherInteractionAffordance> {
     pub(super) forms: Vec<FormBuilder<Other, String, Other::Form>>,
     pub(super) uri_variables: HashMap<String, DataSchemaFromOther<Other>>,
-    pub(super) other: OtherInteractionAffordance,
+    pub other: OtherInteractionAffordance,
 }
 
 impl<Other, OtherInteractionAffordance> Default
@@ -263,7 +263,7 @@ pub struct PropertyAffordanceBuilder<
     pub(super) info: HumanReadableInfo,
     pub(super) data_schema: DataSchema,
     pub(super) observable: Option<bool>,
-    pub(super) other: OtherPropertyAffordance,
+    pub other: OtherPropertyAffordance,
 }
 
 impl<Other, DataSchema, OtherInteractionAffordance, OtherPropertyAffordance> Default
@@ -301,7 +301,7 @@ pub struct ActionAffordanceBuilder<
     pub(super) safe: bool,
     pub(super) idempotent: bool,
     pub(super) synchronous: Option<bool>,
-    pub(super) other: OtherActionAffordance,
+    pub other: OtherActionAffordance,
 }
 
 impl<Other, OtherInteractionAffordance, OtherActionAffordance> Default
@@ -358,7 +358,7 @@ pub struct EventAffordanceBuilder<
     pub(super) data: Option<DataSchemaFromOther<Other>>,
     pub(super) cancellation: Option<DataSchemaFromOther<Other>>,
     pub(super) data_response: Option<DataSchemaFromOther<Other>>,
-    pub(super) other: OtherEventAffordance,
+    pub other: OtherEventAffordance,
 }
 
 type EmptyEventAffordanceBuilder<Other> = EventAffordanceBuilder<

--- a/src/builder/data_schema.rs
+++ b/src/builder/data_schema.rs
@@ -24,7 +24,7 @@ pub struct PartialDataSchemaBuilder<DS, AS, OS, Status> {
     read_only: bool,
     write_only: bool,
     format: Option<String>,
-    other: DS,
+    pub other: DS,
     _marker: PhantomData<Status>,
 }
 
@@ -141,7 +141,7 @@ pub(super) struct PartialDataSchema<DS, AS, OS> {
     pub(super) write_only: bool,
     pub(super) format: Option<String>,
     pub(super) subtype: Option<DataSchemaSubtype<DS, AS, OS>>,
-    pub(super) other: DS,
+    pub other: DS,
 }
 
 /// Basic builder for [`DataSchema`].
@@ -286,7 +286,7 @@ pub struct ArrayDataSchemaBuilder<Inner, DS, AS, OS> {
     items: Vec<DataSchema<DS, AS, OS>>,
     min_items: Option<u32>,
     max_items: Option<u32>,
-    other: AS,
+    pub other: AS,
 }
 
 pub struct NumberDataSchemaBuilder<Inner> {
@@ -306,7 +306,7 @@ pub struct ObjectDataSchemaBuilder<Inner, DS, AS, OS> {
     inner: Inner,
     properties: Vec<(String, DataSchema<DS, AS, OS>)>,
     required: Vec<String>,
-    other: OS,
+    pub other: OS,
 }
 
 pub struct StringDataSchemaBuilder<Inner> {


### PR DESCRIPTION
The field should stay as much user-controlled as possible.