### PR TITLE
Add combo security scheme

### DIFF
--- a/src/thing.rs
+++ b/src/thing.rs
@@ -756,6 +756,7 @@ pub enum KnownSecuritySchemeSubtype {
     #[default]
     NoSec,
     Auto,
+    Combo(ComboSecurityScheme),
     Basic(BasicSecurityScheme),
     Digest(DigestSecurityScheme),
     Bearer(BearerSecurityScheme),
@@ -783,6 +784,14 @@ impl Default for SecuritySchemeSubtype {
     fn default() -> Self {
         Self::Known(KnownSecuritySchemeSubtype::default())
     }
+}
+
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ComboSecurityScheme {
+    OneOf(#[serde_as(as = "OneOrMany<_>")] Vec<String>),
+    AllOf(#[serde_as(as = "OneOrMany<_>")] Vec<String>),
 }
 
 #[skip_serializing_none]

--- a/src/thing.rs
+++ b/src/thing.rs
@@ -2311,4 +2311,47 @@ mod test {
 
         assert_eq!(serde_json::to_value(response).unwrap(), raw_data);
     }
+
+    #[test]
+    fn combo_security_scheme() {
+        let raw_data = json!({
+            "oneOf": "simple",
+        });
+        let combo: ComboSecurityScheme = serde_json::from_value(raw_data.clone()).unwrap();
+        assert_eq!(
+            combo,
+            ComboSecurityScheme::OneOf(vec!["simple".to_string()]),
+        );
+        assert_eq!(serde_json::to_value(combo).unwrap(), raw_data);
+
+        let raw_data = json!({
+            "oneOf": ["data1", "data2"],
+        });
+        let combo: ComboSecurityScheme = serde_json::from_value(raw_data.clone()).unwrap();
+        assert_eq!(
+            combo,
+            ComboSecurityScheme::OneOf(vec!["data1".to_string(), "data2".to_string()]),
+        );
+        assert_eq!(serde_json::to_value(combo).unwrap(), raw_data);
+
+        let raw_data = json!({
+            "allOf": "simple",
+        });
+        let combo: ComboSecurityScheme = serde_json::from_value(raw_data.clone()).unwrap();
+        assert_eq!(
+            combo,
+            ComboSecurityScheme::AllOf(vec!["simple".to_string()]),
+        );
+        assert_eq!(serde_json::to_value(combo).unwrap(), raw_data);
+
+        let raw_data = json!({
+            "allOf": ["data1", "data2"],
+        });
+        let combo: ComboSecurityScheme = serde_json::from_value(raw_data.clone()).unwrap();
+        assert_eq!(
+            combo,
+            ComboSecurityScheme::AllOf(vec!["data1".to_string(), "data2".to_string()]),
+        );
+        assert_eq!(serde_json::to_value(combo).unwrap(), raw_data);
+    }
 }


### PR DESCRIPTION
I would like an opinion about the signature of `all_of`/`one_of`. Currently, I am requiring an `I: IntoIterator<Item = String>`, which leads to some ergonomic rough edges for the user. In fact, I initially wanted to to something like:

```rust
pub fn all_of<I, T>(
    self,
    iter: I,
) -> SecuritySchemeBuilder<(AllOfComboSecuritySchemeTag, Vec<String>)>
where
    I: IntoIterator<Item = T>,
    T: Into<String>
```

but I am a bit worried about eventual issues I am not thinking about (i.e. missing type deduction in some cases). I cannot think about a function in the `std` that takes this kind of generic `IntoIterator`, maybe there could be a reason for this. What do you think @lu-zero?