### PR TITLE
Rename MultiLanguageBuilder::cons into add

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1104,7 +1104,7 @@ impl<T> MultiLanguageBuilder<T> {
     /// Add the language-specific variant
     ///
     /// NOTE: The language key is currently free-form
-    pub fn cons(&mut self, language: impl Into<String>, value: impl Into<T>) -> &mut Self {
+    pub fn add(&mut self, language: impl Into<String>, value: impl Into<T>) -> &mut Self {
         self.values.insert(language.into(), value.into());
         self
     }
@@ -2210,7 +2210,7 @@ mod tests {
     #[test]
     fn titles() {
         let thing = ThingBuilder::<Nil, _>::new("MyLampThing")
-            .titles(|ml| ml.cons("en", "My lamp").cons("it", "La mia lampada"))
+            .titles(|ml| ml.add("en", "My lamp").add("it", "La mia lampada"))
             .build()
             .unwrap();
 
@@ -2234,7 +2234,7 @@ mod tests {
     fn descriptions() {
         let thing = ThingBuilder::<Nil, _>::new("MyLampThing")
             .description("My Lamp")
-            .descriptions(|ml| ml.cons("en", "My lamp").cons("it", "La mia lampada"))
+            .descriptions(|ml| ml.add("en", "My lamp").add("it", "La mia lampada"))
             .build()
             .unwrap();
 
@@ -2365,7 +2365,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
+                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2410,7 +2410,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
+                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2457,7 +2457,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
+                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2510,7 +2510,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
+                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2563,7 +2563,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
+                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2618,7 +2618,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
+                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2676,7 +2676,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
+                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })
@@ -2733,7 +2733,7 @@ mod tests {
                     .attype("ty1")
                     .attype("ty2")
                     .description("desc")
-                    .descriptions(|ml| ml.cons("en", "desc_en").cons("it", "desc_it"))
+                    .descriptions(|ml| ml.add("en", "desc_en").add("it", "desc_it"))
                     .proxy("proxy")
                     .required()
             })

--- a/src/builder/affordance.rs
+++ b/src/builder/affordance.rs
@@ -1915,9 +1915,9 @@ mod test {
                 .attype("attype1")
                 .attype("attype2")
                 .title("title")
-                .titles(|b| b.cons("it", "title_it").cons("en", "title_en"))
+                .titles(|b| b.add("it", "title_it").add("en", "title_en"))
                 .description("description")
-                .descriptions(|b| b.cons("it", "description_it").cons("en", "description_en"))
+                .descriptions(|b| b.add("it", "description_it").add("en", "description_en"))
                 .form(|b| b.href("form1_href").content_type("content_type"))
                 .form(|b| {
                     b.op(FormOperation::WriteProperty)

--- a/src/builder/data_schema.rs
+++ b/src/builder/data_schema.rs
@@ -2626,9 +2626,9 @@ mod tests {
             .attype("attype1")
             .attype("attype2")
             .title("title")
-            .titles(|b| b.cons("en", "title_en").cons("it", "title_it"))
+            .titles(|b| b.add("en", "title_en").add("it", "title_it"))
             .description("description")
-            .descriptions(|b| b.cons("en", "description_en").cons("it", "description_it"))
+            .descriptions(|b| b.add("en", "description_en").add("it", "description_it"))
             .unit("cm")
             .format("format")
             .into();
@@ -2671,9 +2671,9 @@ mod tests {
             .enumeration(3u32)
             .attype("attype")
             .title("title")
-            .titles(|b| b.cons("en", "title_en").cons("it", "title_it"))
+            .titles(|b| b.add("en", "title_en").add("it", "title_it"))
             .description("description")
-            .descriptions(|b| b.cons("en", "description_en").cons("it", "description_it"))
+            .descriptions(|b| b.add("en", "description_en").add("it", "description_it"))
             .unit("cm")
             .format("format")
             .into();


### PR DESCRIPTION
This was accidentally renamed in a commit related to HList. In practice this is a partial revert.