### PR TITLE
Implement stricter and checked multilanguage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/sifis-home/wot-td"
 keywords = ["wot", "WebofThings"]
 
 [dependencies]
+oxilangtag = { version = "0.1.3", features = ["serde"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 serde_with = "2.0.0"

--- a/src/builder/affordance.rs
+++ b/src/builder/affordance.rs
@@ -2967,4 +2967,46 @@ mod test {
             },
         );
     }
+
+    #[test]
+    fn build_invalid_property_affordance() {
+        let builder = PropertyAffordanceBuilder::<
+            Nil,
+            PartialDataSchemaBuilder<_, _, _, _>,
+            (),
+            (),
+        >::default()
+        .number()
+        .titles(|b| b.add("i1t", "title1"))
+        .into_usable();
+
+        assert_eq!(
+            builder.build().unwrap_err(),
+            Error::InvalidLanguageTag("i1t".to_string()),
+        );
+    }
+
+    #[test]
+    fn build_invalid_action_affordance() {
+        let builder = ActionAffordanceBuilder::<Nil, (), ()>::default()
+            .titles(|b| b.add("i1t", "title1"))
+            .into_usable();
+
+        assert_eq!(
+            builder.build().unwrap_err(),
+            Error::InvalidLanguageTag("i1t".to_string()),
+        );
+    }
+
+    #[test]
+    fn build_invalid_event_affordance() {
+        let builder = EventAffordanceBuilder::<Nil, (), ()>::default()
+            .titles(|b| b.add("i1t", "title1"))
+            .into_usable();
+
+        assert_eq!(
+            builder.build().unwrap_err(),
+            Error::InvalidLanguageTag("i1t".to_string()),
+        );
+    }
 }

--- a/src/builder/data_schema.rs
+++ b/src/builder/data_schema.rs
@@ -4151,4 +4151,396 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn valid_unchecked_array_data_schema() {
+        let data_schema = UncheckedArraySchema::<Nil, Nil, Nil> {
+            items: Some(vec![
+                UncheckedDataSchema {
+                    titles: Some({
+                        let mut multilang = MultiLanguageBuilder::default();
+                        multilang.add("it", "title1").add("en", "title2");
+                        multilang
+                    }),
+                    descriptions: Some({
+                        let mut multilang = MultiLanguageBuilder::default();
+                        multilang
+                            .add("it", "description1")
+                            .add("en", "description2");
+                        multilang
+                    }),
+                    ..Default::default()
+                },
+                UncheckedDataSchema {
+                    titles: Some({
+                        let mut multilang = MultiLanguageBuilder::default();
+                        multilang.add("it", "title3").add("en", "title4");
+                        multilang
+                    }),
+                    descriptions: Some({
+                        let mut multilang = MultiLanguageBuilder::default();
+                        multilang
+                            .add("it", "description3")
+                            .add("en", "description4");
+                        multilang
+                    }),
+                    ..Default::default()
+                },
+            ]),
+            min_items: Some(1),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            ArraySchema::try_from(data_schema).unwrap(),
+            ArraySchema {
+                items: Some(vec![
+                    DataSchema {
+                        titles: Some(
+                            [
+                                ("it".parse().unwrap(), "title1".to_string()),
+                                ("en".parse().unwrap(), "title2".to_string())
+                            ]
+                            .into_iter()
+                            .collect()
+                        ),
+                        descriptions: Some(
+                            [
+                                ("it".parse().unwrap(), "description1".to_string()),
+                                ("en".parse().unwrap(), "description2".to_string())
+                            ]
+                            .into_iter()
+                            .collect()
+                        ),
+                        ..Default::default()
+                    },
+                    DataSchema {
+                        titles: Some(
+                            [
+                                ("it".parse().unwrap(), "title3".to_string()),
+                                ("en".parse().unwrap(), "title4".to_string())
+                            ]
+                            .into_iter()
+                            .collect()
+                        ),
+                        descriptions: Some(
+                            [
+                                ("it".parse().unwrap(), "description3".to_string()),
+                                ("en".parse().unwrap(), "description4".to_string())
+                            ]
+                            .into_iter()
+                            .collect()
+                        ),
+                        ..Default::default()
+                    },
+                ]),
+                min_items: Some(1),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_unchecked_array_data_schema() {
+        let data_schema = UncheckedArraySchema::<Nil, Nil, Nil> {
+            items: Some(vec![
+                UncheckedDataSchema {
+                    titles: Some({
+                        let mut multilang = MultiLanguageBuilder::default();
+                        multilang.add("it", "title1").add("en", "title2");
+                        multilang
+                    }),
+                    descriptions: Some({
+                        let mut multilang = MultiLanguageBuilder::default();
+                        multilang
+                            .add("it", "description1")
+                            .add("en", "description2");
+                        multilang
+                    }),
+                    ..Default::default()
+                },
+                UncheckedDataSchema {
+                    titles: Some({
+                        let mut multilang = MultiLanguageBuilder::default();
+                        multilang.add("it", "title3").add("en", "title4");
+                        multilang
+                    }),
+                    descriptions: Some({
+                        let mut multilang = MultiLanguageBuilder::default();
+                        multilang
+                            .add("it", "description3")
+                            .add("e1n", "description4");
+                        multilang
+                    }),
+                    ..Default::default()
+                },
+            ]),
+            min_items: Some(1),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            ArraySchema::try_from(data_schema).unwrap_err(),
+            Error::InvalidLanguageTag("e1n".to_string()),
+        );
+    }
+
+    #[test]
+    fn valid_unchecked_object_data_schema() {
+        let data_schema = UncheckedObjectSchema::<Nil, Nil, Nil> {
+            properties: Some(
+                [
+                    (
+                        "data1".to_string(),
+                        UncheckedDataSchema {
+                            titles: Some({
+                                let mut multilang = MultiLanguageBuilder::default();
+                                multilang.add("it", "title1").add("en", "title2");
+                                multilang
+                            }),
+                            descriptions: Some({
+                                let mut multilang = MultiLanguageBuilder::default();
+                                multilang
+                                    .add("it", "description1")
+                                    .add("en", "description2");
+                                multilang
+                            }),
+                            ..Default::default()
+                        },
+                    ),
+                    (
+                        "data2".to_string(),
+                        UncheckedDataSchema {
+                            titles: Some({
+                                let mut multilang = MultiLanguageBuilder::default();
+                                multilang.add("it", "title3").add("en", "title4");
+                                multilang
+                            }),
+                            descriptions: Some({
+                                let mut multilang = MultiLanguageBuilder::default();
+                                multilang
+                                    .add("it", "description3")
+                                    .add("en", "description4");
+                                multilang
+                            }),
+                            ..Default::default()
+                        },
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            ObjectSchema::try_from(data_schema).unwrap(),
+            ObjectSchema {
+                properties: Some(
+                    [
+                        (
+                            "data1".to_string(),
+                            DataSchema {
+                                titles: Some(
+                                    [
+                                        ("it".parse().unwrap(), "title1".to_string()),
+                                        ("en".parse().unwrap(), "title2".to_string())
+                                    ]
+                                    .into_iter()
+                                    .collect()
+                                ),
+                                descriptions: Some(
+                                    [
+                                        ("it".parse().unwrap(), "description1".to_string()),
+                                        ("en".parse().unwrap(), "description2".to_string())
+                                    ]
+                                    .into_iter()
+                                    .collect()
+                                ),
+                                ..Default::default()
+                            }
+                        ),
+                        (
+                            "data2".to_string(),
+                            DataSchema {
+                                titles: Some(
+                                    [
+                                        ("it".parse().unwrap(), "title3".to_string()),
+                                        ("en".parse().unwrap(), "title4".to_string())
+                                    ]
+                                    .into_iter()
+                                    .collect()
+                                ),
+                                descriptions: Some(
+                                    [
+                                        ("it".parse().unwrap(), "description3".to_string()),
+                                        ("en".parse().unwrap(), "description4".to_string())
+                                    ]
+                                    .into_iter()
+                                    .collect()
+                                ),
+                                ..Default::default()
+                            }
+                        ),
+                    ]
+                    .into_iter()
+                    .collect()
+                ),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_unchecked_object_data_schema() {
+        let data_schema = UncheckedObjectSchema::<Nil, Nil, Nil> {
+            properties: Some(
+                [
+                    (
+                        "data1".to_string(),
+                        UncheckedDataSchema {
+                            titles: Some({
+                                let mut multilang = MultiLanguageBuilder::default();
+                                multilang.add("it", "title1").add("en", "title2");
+                                multilang
+                            }),
+                            descriptions: Some({
+                                let mut multilang = MultiLanguageBuilder::default();
+                                multilang
+                                    .add("it", "description1")
+                                    .add("en", "description2");
+                                multilang
+                            }),
+                            ..Default::default()
+                        },
+                    ),
+                    (
+                        "data2".to_string(),
+                        UncheckedDataSchema {
+                            titles: Some({
+                                let mut multilang = MultiLanguageBuilder::default();
+                                multilang.add("it", "title3").add("en", "title4");
+                                multilang
+                            }),
+                            descriptions: Some({
+                                let mut multilang = MultiLanguageBuilder::default();
+                                multilang
+                                    .add("i1t", "description3")
+                                    .add("en", "description4");
+                                multilang
+                            }),
+                            ..Default::default()
+                        },
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            ObjectSchema::try_from(data_schema).unwrap_err(),
+            Error::InvalidLanguageTag("i1t".to_string()),
+        )
+    }
+
+    #[test]
+    fn valid_unchecked_data_schema() {
+        let data_schema = UncheckedDataSchema::<Nil, Nil, Nil> {
+            attype: Some(vec!["attype1".to_string(), "attype2".to_string()]),
+            title: Some("title".to_string()),
+            titles: Some({
+                let mut multilang = MultiLanguageBuilder::default();
+                multilang.add("it", "title1").add("en", "title2");
+                multilang
+            }),
+            description: Some("description".to_string()),
+            descriptions: Some({
+                let mut multilang = MultiLanguageBuilder::default();
+                multilang
+                    .add("it", "description1")
+                    .add("en", "description2");
+                multilang
+            }),
+            unit: Some("unit".to_string()),
+            read_only: true,
+            write_only: true,
+            format: Some("format".to_string()),
+            subtype: Some(UncheckedDataSchemaSubtype::Number(NumberSchema {
+                maximum: Some(5.),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            DataSchema::try_from(data_schema).unwrap(),
+            DataSchema {
+                attype: Some(vec!["attype1".to_string(), "attype2".to_string()]),
+                title: Some("title".to_string()),
+                titles: Some(
+                    [
+                        ("it".parse().unwrap(), "title1".to_string()),
+                        ("en".parse().unwrap(), "title2".to_string())
+                    ]
+                    .into_iter()
+                    .collect()
+                ),
+                description: Some("description".to_string()),
+                descriptions: Some(
+                    [
+                        ("it".parse().unwrap(), "description1".to_string()),
+                        ("en".parse().unwrap(), "description2".to_string())
+                    ]
+                    .into_iter()
+                    .collect()
+                ),
+                unit: Some("unit".to_string()),
+                read_only: true,
+                write_only: true,
+                format: Some("format".to_string()),
+                subtype: Some(DataSchemaSubtype::Number(NumberSchema {
+                    maximum: Some(5.),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_unchecked_data_schema() {
+        let data_schema = UncheckedDataSchema::<Nil, Nil, Nil> {
+            attype: Some(vec!["attype1".to_string(), "attype2".to_string()]),
+            title: Some("title".to_string()),
+            titles: Some({
+                let mut multilang = MultiLanguageBuilder::default();
+                multilang.add("it", "title1").add("en", "title2");
+                multilang
+            }),
+            description: Some("description".to_string()),
+            descriptions: Some({
+                let mut multilang = MultiLanguageBuilder::default();
+                multilang
+                    .add("i1t", "description1")
+                    .add("en", "description2");
+                multilang
+            }),
+            unit: Some("unit".to_string()),
+            read_only: true,
+            write_only: true,
+            format: Some("format".to_string()),
+            subtype: Some(UncheckedDataSchemaSubtype::Number(NumberSchema {
+                maximum: Some(5.),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            DataSchema::try_from(data_schema).unwrap_err(),
+            Error::InvalidLanguageTag("i1t".to_string()),
+        );
+    }
 }

--- a/src/builder/human_readable_info.rs
+++ b/src/builder/human_readable_info.rs
@@ -3,8 +3,6 @@
 //! This module contains the logic shared across multiple builders for the respective
 //! Thing Description Vocabulary definitions.
 
-use crate::thing::MultiLanguage;
-
 use super::MultiLanguageBuilder;
 
 /// Human readable informations and semantic tagging
@@ -16,11 +14,11 @@ pub struct HumanReadableInfo {
     /// Human readable title in the default language
     pub(super) title: Option<String>,
     /// Human redable title, multilanguage
-    pub(super) titles: Option<MultiLanguage>,
+    pub(super) titles: Option<MultiLanguageBuilder<String>>,
     /// Human readable description in the default language
     pub(super) description: Option<String>,
     /// Human readable description, multilanguage
-    pub(super) descriptions: Option<MultiLanguage>,
+    pub(super) descriptions: Option<MultiLanguageBuilder<String>>,
 }
 
 /// Trait shared across builders dealing with the same information
@@ -70,7 +68,7 @@ impl BuildableHumanReadableInfo for HumanReadableInfo {
     {
         let mut builder = MultiLanguageBuilder::default();
         f(&mut builder);
-        self.titles = Some(builder.values);
+        self.titles = Some(builder);
         self
     }
 
@@ -85,7 +83,7 @@ impl BuildableHumanReadableInfo for HumanReadableInfo {
     {
         let mut builder = MultiLanguageBuilder::default();
         f(&mut builder);
-        self.descriptions = Some(builder.values);
+        self.descriptions = Some(builder);
         self
     }
 }


### PR DESCRIPTION
This PR is a bit messy, because we now have a _fallible element_ deep in the tree, but in order to keep good ergonomics for the user it is necessary to fail only on `build`. This means that we need to keep both the unchecked and the checked versions of many structs around.