### PR TITLE
Support both inclusive & exclusive minimum/maximum values

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2131,7 +2131,8 @@ mod tests {
         hlist::{Cons, Nil},
         thing::{
             ActionAffordance, DataSchema, DataSchemaSubtype, EventAffordance,
-            InteractionAffordance, NumberSchema, ObjectSchema, PropertyAffordance, StringSchema,
+            InteractionAffordance, Maximum, Minimum, NumberSchema, ObjectSchema,
+            PropertyAffordance, StringSchema,
         },
     };
 
@@ -3641,7 +3642,7 @@ mod tests {
                             "schema2".to_string(),
                             DataSchema {
                                 subtype: Some(DataSchemaSubtype::Number(NumberSchema {
-                                    minimum: Some(5.),
+                                    minimum: Some(Minimum::Inclusive(5.)),
                                     ..Default::default()
                                 })),
                                 ..Default::default()
@@ -4241,8 +4242,8 @@ mod tests {
                             input: Some(DataSchema {
                                 title: Some("input".to_string()),
                                 subtype: Some(DataSchemaSubtype::Number(NumberSchema {
-                                    minimum: Some(0.),
-                                    maximum: Some(5.),
+                                    minimum: Some(Minimum::Inclusive(0.)),
+                                    maximum: Some(Maximum::Inclusive(5.)),
                                     ..Default::default()
                                 })),
                                 other: Nil::cons(DataSchemaExtA { h: 25 })

--- a/src/builder/affordance.rs
+++ b/src/builder/affordance.rs
@@ -2033,7 +2033,7 @@ mod test {
         hlist::{Cons, Nil},
         thing::{
             DataSchemaFromOther, DataSchemaSubtype, DefaultedFormOperations, FormOperation,
-            NumberSchema,
+            Minimum, NumberSchema,
         },
     };
 
@@ -2176,7 +2176,7 @@ mod test {
                     default: Some(json! { ["hello", "world"] }),
                     read_only: true,
                     subtype: Some(DataSchemaSubtype::Number(NumberSchema {
-                        minimum: Some(0.),
+                        minimum: Some(Minimum::Inclusive(0.)),
                         ..Default::default()
                     })),
                     ..Default::default()
@@ -2313,7 +2313,7 @@ mod test {
                     unit: Some("cm".to_owned()),
                     read_only: true,
                     subtype: Some(DataSchemaSubtype::Number(NumberSchema {
-                        minimum: Some(0.),
+                        minimum: Some(Minimum::Inclusive(0.)),
                         ..Default::default()
                     })),
                     ..Default::default()
@@ -2366,7 +2366,7 @@ mod test {
                     unit: Some("cm".to_owned()),
                     read_only: true,
                     subtype: Some(DataSchemaSubtype::Number(NumberSchema {
-                        minimum: Some(0.),
+                        minimum: Some(Minimum::Inclusive(0.)),
                         ..Default::default()
                     })),
                     ..Default::default()
@@ -2375,7 +2375,7 @@ mod test {
                     unit: Some("cm".to_owned()),
                     read_only: true,
                     subtype: Some(DataSchemaSubtype::Number(NumberSchema {
-                        minimum: Some(0.),
+                        minimum: Some(Minimum::Inclusive(0.)),
                         ..Default::default()
                     })),
                     ..Default::default()
@@ -2420,7 +2420,7 @@ mod test {
                     unit: Some("cm".to_owned()),
                     read_only: true,
                     subtype: Some(DataSchemaSubtype::Number(NumberSchema {
-                        minimum: Some(0.),
+                        minimum: Some(Minimum::Inclusive(0.)),
                         ..Default::default()
                     })),
                     ..Default::default()
@@ -2469,7 +2469,7 @@ mod test {
                     unit: Some("cm".to_owned()),
                     read_only: true,
                     subtype: Some(DataSchemaSubtype::Number(NumberSchema {
-                        minimum: Some(0.),
+                        minimum: Some(Minimum::Inclusive(0.)),
                         ..Default::default()
                     })),
                     ..Default::default()


### PR DESCRIPTION
I explicitly decided to allow either the inclusive or the exclusive _variant_, never both. This could seems arbitrarily strict, but it avoids a level of ambiguity that something would have to handle at some point. It seems a reasonable solution. 

Let me know if we want to have a custom `Deserialize` impl in order to allow bogus json with both inclusive and exclusive variants.