### PR TITLE
Add sizes and hreflang to Link

### DIFF
--- a/src/thing.rs
+++ b/src/thing.rs
@@ -1167,6 +1167,8 @@ impl OAuth2SecurityScheme {
     }
 }
 
+#[serde_as]
+#[skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct Link {
     pub href: String,
@@ -1178,6 +1180,12 @@ pub struct Link {
 
     // FIXME: use AnyURI
     pub anchor: Option<String>,
+
+    pub sizes: Option<String>,
+
+    #[serde(default)]
+    #[serde_as(as = "Option<OneOrMany<_>>")]
+    pub hreflang: Option<Vec<LanguageTag<String>>>,
 }
 
 #[serde_as]


### PR DESCRIPTION
We are adding only two checks in this phase:
- Language tags in `hreflang` must be valid.
- If `sizes` is specified, then `rel` must be equal to `sizes`.

This means that we are still not providing an abstract type to correctly handle sizes at compile time. Moreover, the _coherency_ check between `sizes` and `rel` is performed at runtime.