### PR TITLE
fix: use correct TD 1.1 @context URI

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -101,7 +101,7 @@
 //! assert_eq!(
 //!     serde_json::to_value(thing).unwrap(),
 //!     json!({
-//!         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+//!         "@context": "https://www.w3.org/2022/wot/td/v1.1",
 //!         "title": "Thing name",
 //!         "a_field": "hello world",
 //!         "another_field": 42,
@@ -186,7 +186,7 @@
 //! assert_eq!(
 //!     serde_json::to_value(thing).unwrap(),
 //!     json!({
-//!         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+//!         "@context": "https://www.w3.org/2022/wot/td/v1.1",
 //!         "title": "Thing name",
 //!         "a_field": "hello world",
 //!         "another_field": 42,
@@ -626,7 +626,7 @@ impl<Other: ExtendableThing> ThingBuilder<Other, ToExtend> {
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "a_field": "hello world",
     ///         "another_field": 42,
@@ -736,7 +736,7 @@ impl<Other: ExtendableThing> ThingBuilder<Other, ToExtend> {
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "a_field": "hello world",
     ///         "another_field": 42,
@@ -1108,7 +1108,7 @@ impl<Other: ExtendableThing, Status> ThingBuilder<Other, Status> {
     ///     json!({
     ///         "title": "Thing name",
     ///         "@context": [
-    ///             "https://www.w3.org/2019/wot/td/v1.1",
+    ///             "https://www.w3.org/2022/wot/td/v1.1",
     ///             {
     ///                 "custom_context1": "hello",
     ///                 "custom_context2": "world",
@@ -1159,7 +1159,7 @@ impl<Other: ExtendableThing, Status> ThingBuilder<Other, Status> {
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
     ///         "title": "Thing name",
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "titles": {
     ///             "en": "English title",
     ///             "it": "Italian title",
@@ -1246,7 +1246,7 @@ impl<Other: ExtendableThing, Status> ThingBuilder<Other, Status> {
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
     ///         "title": "Thing name",
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "links": [{
     ///             "href": "https://localhost",
     ///             "rel": "icon",
@@ -1306,7 +1306,7 @@ impl<Other: ExtendableThing, Status> ThingBuilder<Other, Status> {
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
     ///         "title": "Thing name",
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "security": [],
     ///         "securityDefinitions": {
     ///             "my_basic_sec": {
@@ -1422,7 +1422,7 @@ where
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
     ///         "title": "Thing name",
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "forms": [
     ///             {
     ///                 "href": "form_href",
@@ -1523,7 +1523,7 @@ where
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
     ///         "title": "Thing name",
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "uriVariables": {
     ///             "var": {
     ///                 "type": "number",
@@ -2328,7 +2328,7 @@ pub mod security {
         ///     serde_json::to_value(thing).unwrap(),
         ///     json!({
         ///         "title": "Thing name",
-        ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+        ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
         ///         "security": [],
         ///         "securityDefinitions": {
         ///             "combo": {
@@ -2412,7 +2412,7 @@ pub mod security {
         ///     serde_json::to_value(thing).unwrap(),
         ///     json!({
         ///         "title": "Thing name",
-        ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+        ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
         ///         "security": [],
         ///         "securityDefinitions": {
         ///             "combo": {
@@ -2737,7 +2737,7 @@ where
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
     ///         "title": "Thing name",
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "forms": [{
     ///             "href": "form_href",
     ///             "op": ["readallproperties"],

--- a/src/builder/affordance.rs
+++ b/src/builder/affordance.rs
@@ -79,7 +79,7 @@ pub trait BuildableInteractionAffordance<Other: ExtendableThing> {
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
     ///         "title": "Thing name",
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "actions": {
     ///             "aff": {
     ///                 "forms": [{
@@ -122,7 +122,7 @@ pub trait BuildableInteractionAffordance<Other: ExtendableThing> {
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
     ///         "title": "Thing name",
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "actions": {
     ///             "aff": {
     ///                 "forms": [],
@@ -501,7 +501,7 @@ impl_buildable_interaction_affordance!(
 /// assert_eq!(
 ///     serde_json::to_value(thing).unwrap(),
 ///     json!({
-///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
 ///         "title": "Thing name",
 ///         "a_field": "hello world",
 ///         "another_field": 42,
@@ -671,7 +671,7 @@ where
 /// assert_eq!(
 ///     serde_json::to_value(thing).unwrap(),
 ///     json!({
-///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
 ///         "title": "Thing name",
 ///         "a_field": "hello world",
 ///         "another_field": 42,
@@ -864,7 +864,7 @@ where
 /// assert_eq!(
 ///     serde_json::to_value(thing).unwrap(),
 ///     json!({
-///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
 ///         "title": "Thing name",
 ///         "a_field": "hello world",
 ///         "another_field": 42,
@@ -1851,7 +1851,7 @@ impl<Other: ExtendableThing, OtherInteractionAffordance, OtherActionAffordance>
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "actions": {
     ///             "action": {
@@ -1931,7 +1931,7 @@ impl<Other: ExtendableThing, OtherInteractionAffordance, OtherActionAffordance>
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "actions": {
     ///             "action": {
@@ -2033,7 +2033,7 @@ impl<Other: ExtendableThing, OtherInteractionAffordance, OtherEventAffordance>
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "events": {
     ///             "event": {
@@ -2109,7 +2109,7 @@ impl<Other: ExtendableThing, OtherInteractionAffordance, OtherEventAffordance>
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "events": {
     ///             "event": {
@@ -2185,7 +2185,7 @@ impl<Other: ExtendableThing, OtherInteractionAffordance, OtherEventAffordance>
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "events": {
     ///             "event": {
@@ -2261,7 +2261,7 @@ impl<Other: ExtendableThing, OtherInteractionAffordance, OtherEventAffordance>
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "events": {
     ///             "event": {

--- a/src/builder/data_schema.rs
+++ b/src/builder/data_schema.rs
@@ -347,7 +347,7 @@ pub struct PartialDataSchema<DS, AS, OS> {
 /// assert_eq!(
 ///     serde_json::to_value(thing).unwrap(),
 ///     json!({
-///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
 ///         "title": "Thing name",
 ///         "schemaDefinitions": {
 ///             "test": {
@@ -524,7 +524,7 @@ pub trait SpecializableDataSchema<DS, AS, OS>: BuildableDataSchema<DS, AS, OS, E
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "schemaDefinitions": {
     ///             "test": {
@@ -632,7 +632,7 @@ pub trait SpecializableDataSchema<DS, AS, OS>: BuildableDataSchema<DS, AS, OS, E
     /// # assert_eq!(
     /// #     serde_json::to_value(thing).unwrap(),
     /// #     json!({
-    /// #         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    /// #         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     /// #         "title": "Thing name",
     /// #         "schemaDefinitions": {
     /// #             "test": {
@@ -705,7 +705,7 @@ pub trait SpecializableDataSchema<DS, AS, OS>: BuildableDataSchema<DS, AS, OS, E
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "schemaDefinitions": {
     ///             "test": {
@@ -781,7 +781,7 @@ pub trait SpecializableDataSchema<DS, AS, OS>: BuildableDataSchema<DS, AS, OS, E
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "schemaDefinitions": {
     ///             "test": {
@@ -889,7 +889,7 @@ pub trait SpecializableDataSchema<DS, AS, OS>: BuildableDataSchema<DS, AS, OS, E
     /// # assert_eq!(
     /// #     serde_json::to_value(thing).unwrap(),
     /// #     json!({
-    /// #         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    /// #         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     /// #         "title": "Thing name",
     /// #         "schemaDefinitions": {
     /// #             "test": {
@@ -962,7 +962,7 @@ pub trait SpecializableDataSchema<DS, AS, OS>: BuildableDataSchema<DS, AS, OS, E
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "schemaDefinitions": {
     ///             "test": {
@@ -1032,7 +1032,7 @@ pub trait EnumerableDataSchema<DS, AS, OS, Extended>:
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "schemaDefinitions": {
     ///             "test": {
@@ -1089,7 +1089,7 @@ pub trait UnionDataSchema<DS, AS, OS>: BuildableDataSchema<DS, AS, OS, Extended>
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "schemaDefinitions": {
     ///             "test": {
@@ -1173,7 +1173,7 @@ pub trait ReadableWriteableDataSchema<DS, AS, OS, Extended>:
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "schemaDefinitions": {
     ///             "test": {
@@ -1350,7 +1350,7 @@ pub trait ArrayDataSchemaBuilderLike<DS, AS, OS> {
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "schemaDefinitions": {
     ///             "test": {
@@ -1437,7 +1437,7 @@ pub trait ObjectDataSchemaBuilderLike<DS, AS, OS> {
     /// assert_eq!(
     ///     serde_json::to_value(thing).unwrap(),
     ///     json!({
-    ///         "@context": "https://www.w3.org/2019/wot/td/v1.1",
+    ///         "@context": "https://www.w3.org/2022/wot/td/v1.1",
     ///         "title": "Thing name",
     ///         "schemaDefinitions": {
     ///             "test": {

--- a/src/thing.rs
+++ b/src/thing.rs
@@ -42,7 +42,7 @@ pub const TD_CONTEXT_10: &str = "https://www.w3.org/2019/wot/td/v1";
 
 /// The JSON-LD context for the version 1.1 of the [Thing
 /// description](https://www.w3.org/TR/wot-thing-description11/)
-pub const TD_CONTEXT_11: &str = "https://www.w3.org/2019/wot/td/v1.1";
+pub const TD_CONTEXT_11: &str = "https://www.w3.org/2022/wot/td/v1.1";
 
 /// An abstraction of a physical or a virtual entity
 ///
@@ -1732,7 +1732,7 @@ mod test {
     fn minimal_thing() {
         const RAW: &str = r#"
         {
-            "@context": "https://www.w3.org/2019/wot/td/v1.1",
+            "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "id": "urn:dev:ops:32473-WoTLamp-1234",
             "title": "MyLampThing",
             "securityDefinitions": {
@@ -1763,7 +1763,7 @@ mod test {
     fn complete_thing() {
         const RAW: &str = r#"
         {
-          "@context": "https://www.w3.org/2019/wot/td/v1.1",
+          "@context": "https://www.w3.org/2022/wot/td/v1.1",
           "id": "urn:dev:ops:32473-WoTLamp-1234",
           "@type": [
             "Thing",


### PR DESCRIPTION
Validating a TD produced by the crate, I noticed that currently a slightly incorrect @context URI (`https://www.w3.org/2019/wot/td/v1.1`) for version 1.1 TDs is being used.

This PR simply changes the value to `https://www.w3.org/2022/wot/td/v1.1` (c.f. https://w3c.github.io/wot-thing-description/#namespaces), making the crate specification-compliant again.