### PR TITLE
fix: Avoid problematic serde release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["wot", "WebofThings"]
 
 [dependencies]
 oxilangtag = { version = "0.1.3", features = ["serde"] }
-serde = { version = "1.0.137", features = ["derive"] }
+serde = { version = "1.0.137, < 1.0.172", features = ["derive"] }
 serde_json = "1.0.81"
 serde_repr = "0.1.9"
 serde_with = "2.0.0"


### PR DESCRIPTION
serde 1.0.172 and up rely on opaque non-reproducible binary blobs to function on certain targets, explicitly not providing a library-level opt-out.

This is problematic for some reasons, those that I consider more problematic:
- unauditable binary blobs are a security concern.
- the binary is produced cutting few corners (e.g. using a non-dropping allocator).

See serde-rs/serde#2538 for the full discussion.