### PR TITLE
fix: Remove redundant use of then exported items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ oxilangtag = { version = "0.1.3", features = ["serde"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 serde_repr = "0.1.9"
-serde_with = "2.0.0"
+serde_with = "3.4.0"
 thiserror = "1.0.31"
 time = { version = "0.3.11", features = ["serde", "serde-well-known"] }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -224,13 +224,12 @@ use crate::{
 
 use self::{
     affordance::{
-        AffordanceBuilder, BuildableAffordance, CheckableInteractionAffordanceBuilder, IntoUsable,
+        AffordanceBuilder, BuildableAffordance, CheckableInteractionAffordanceBuilder,
         UsableActionAffordanceBuilder, UsableEventAffordanceBuilder,
         UsablePropertyAffordanceBuilder,
     },
     data_schema::{
-        uri_variables_contains_arrays_objects, CheckableDataSchema, PartialDataSchemaBuilder,
-        UncheckedDataSchemaFromOther,
+        uri_variables_contains_arrays_objects, CheckableDataSchema, UncheckedDataSchemaFromOther,
     },
 };
 


### PR DESCRIPTION
Fixes `warning: private item shadows public glob re-export`